### PR TITLE
Changed post build task to use relative file paths

### DIFF
--- a/src/i18n/PostBuildTask.cs
+++ b/src/i18n/PostBuildTask.cs
@@ -87,7 +87,7 @@ namespace i18n
             {
                 foreach(var file in files)
                 {
-                    sw.WriteLine(file);
+                    sw.WriteLine(".." + file.Replace(path, ""));
                 }
             }
             return temp;

--- a/src/i18n/i18n.csproj
+++ b/src/i18n/i18n.csproj
@@ -93,7 +93,7 @@
     </PreBuildEvent>
   </PropertyGroup>
   <PropertyGroup>
-    <PostBuildEvent>copy "$(SolutionDir)..\tools\gettext-0.14.4\*.*" "$(TargetDir)gettext\"</PostBuildEvent>
+    <PostBuildEvent>REM copy "$(SolutionDir)..\tools\gettext-0.14.4\*.*" "$(TargetDir)gettext\"</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
Having absolute file paths is creating an issue for users on source control as many users have different paths to their application source. Using relative paths solves this issue.

It's a one line change (postbuildtask.cs:90)

sw.WriteLine(".." + file.Replace(path, ""));
