### PR TITLE
Ignore obsolete messages

### DIFF
--- a/src/i18n/LocalizingService.cs
+++ b/src/i18n/LocalizingService.cs
@@ -206,6 +206,11 @@ namespace i18n
                     string line;
                     while ((line = fs.ReadLine()) != null)
                     {
+                        if (line.StartsWith("#~"))
+                        {
+                            continue;
+                        }
+
                         var message = new I18NMessage();
                         var sb = new StringBuilder();
 


### PR DESCRIPTION
i18n borked with NullReferenceExceptions on lines that appeared in our .po files starting with "#~".

These lines appear to be "obsolete" entries - ie, entries that were translated, but later removed. Not too many references to them to be honest, one here:

http://www.gnu.org/software/gettext/manual/gettext.html#msgattrib-Invocation
