### PR TITLE
Same as I committed months ago, when the msgid only has one character, the regex will not match e.g. \"Y\", I'm not able to give a right regular expression, if you can correct the regular expression, that would be fine.

### DIFF
--- a/src/i18n/LocalizingService.cs
+++ b/src/i18n/LocalizingService.cs
@@ -249,9 +249,11 @@ namespace i18n
             {
                 if(line.StartsWith("msgid"))
                 {
-                    var msgid = quoted.Match(line).Value;
-                    sb.Append(msgid.Substring(1, msgid.Length - 2));
-                    
+                    int firstIndex = line.IndexOf('\"');
+                    int lastIndex = line.LastIndexOf('\"');
+                    var msgid = line.Substring(firstIndex + 1, lastIndex - firstIndex - 1);
+                    sb.Append(msgid);
+
                     while ((line = fs.ReadLine()) != null && !line.StartsWith("msgstr") && !string.IsNullOrWhiteSpace(msgid = quoted.Match(line).Value))
                     {
                         sb.Append(msgid.Substring(1, msgid.Length - 2));


### PR DESCRIPTION
Same as I committed months ago, when the msgid only has one character, the regex will not match e.g. \"Y\", I'm not able to give a right regular expression, if you can correct the regular expression, that would be fine.

Thanks.
