### PR TITLE
check for lt returned by GetCachedInstance being null

### DIFF
--- a/src/i18n/LanguageItem.cs
+++ b/src/i18n/LanguageItem.cs
@@ -149,7 +149,7 @@ namespace i18n
                 string langtag = headerval.Substring(begin, pos1 -begin).Trim();
                // Wrap langtag.
                 LanguageTag lt = i18n.LanguageTag.GetCachedInstance(langtag);
-                if (!lt.Language.IsSet()) {
+                if (lt==null || !lt.Language.IsSet()) {
                     continue; }
                // Ignore the langtag if already added.
                 if (pal.IsValid() && pal.Equals(lt)) {


### PR DESCRIPTION
Under some very weird circunstances that I haven't been able to reproduce but I'm seeing the logs for, lt is null. 
Since GetCachedInstance returns a null in some instances I would also argue this check should be in place anyways to avoid the null reference exception when the conditions for that null return occur.
