### PR TITLE
Fix for working with msgid with non-ASCII characters (e.g when using non-english language as base language)

### DIFF
--- a/src/i18n/PostBuildTask.cs
+++ b/src/i18n/PostBuildTask.cs
@@ -55,7 +55,7 @@ namespace i18n
         private static void CreateMessageTemplate(string outputPath, string manifest, string options)
         {
             // http://www.gnu.org/s/hello/manual/gettext/xgettext-Invocation.html
-            var args = string.Format("{2} -LC# -k_ -k__ --omit-header --from-code=UTF-8 -o\"{0}\\locale\\messages.pot\" -f\"{1}\"", outputPath, manifest, options);
+            var args = string.Format("{2} -LC# -k_ -k__ --from-code=UTF-8 -o\"{0}\\locale\\messages.pot\" -f\"{1}\"", outputPath, manifest, options);
             RunWithOutput("gettext\\xgettext.exe", args); // Mark H bodge
         }
 


### PR DESCRIPTION
Removed --omit-header, as, as it stated in docs it causes errors with non-ASCII msgids, which happened to us:).

Reference: http://www.gnu.org/software/gettext/manual/gettext.html#xgettext-Invocation
5.1.7 Output details:

‘--omit-header’
Don't write header with ‘msgid ""’ entry.
This is useful for testing purposes because it eliminates a source of variance for generated .gmo files. With --omit-header, two invocations of xgettext on the same files with the same options at different times are guaranteed to produce the same results.

Note that using this option will lead to an error if the resulting file would not entirely be in ASCII.
