### PR TITLE
poedit (and wikipedia) wants empty msgstr entries in template file

### DIFF
--- a/src/i18n.Domain/Concrete/POTranslationRepository.cs
+++ b/src/i18n.Domain/Concrete/POTranslationRepository.cs
@@ -281,6 +281,7 @@ namespace i18n.Domain.Concrete
 					}
 
 					stream.WriteLine("msgid \"" + escape(item.MsgId) + "\"");
+					stream.WriteLine("msgstr \"\"");
 					stream.WriteLine("");
 				}
 			}


### PR DESCRIPTION
POEdit claims that the .pot file is an invalid template file unless there are empty msgstr-entries present. This also matches how Wikipedia denotes the format at http://en.wikipedia.org/wiki/Gettext
