### PR TITLE
Issue #110, formatting with empty parameter leaves delimiters intact

### DIFF
--- a/src/i18n.Domain.Tests/NuggetParserTests.cs
+++ b/src/i18n.Domain.Tests/NuggetParserTests.cs
@@ -185,5 +185,22 @@ namespace i18n.Domain.Tests
                 return null;
             });
         }
+
+        [TestMethod]
+        [Description("Issue #110: Parsing an empty parameter should not leave ']]]' intact.")]
+        public void NuggetParser_CanParseEntity_EmptyParam() {
+            var nuggetTokens = new NuggetTokens("[[[", "]]]", "|||", "///");
+            var nuggetParser = new NuggetParser(nuggetTokens);
+            var input = "[[[Title: %0|||]]]";
+            var result = nuggetParser.ParseString(input, (nuggetString, pos, nugget, i_entity) => {
+                Assert.IsTrue(nugget.IsFormatted);
+
+                var message = NuggetLocalizer.ConvertIdentifiersInMsgId(nugget.MsgId);
+                message = String.Format(message, nugget.FormatItems);
+                return message;
+            });
+
+            Assert.AreEqual("Title: ", result);
+        }
     }
 }

--- a/src/i18n.Domain.Tests/i18n.Domain.Tests.csproj
+++ b/src/i18n.Domain.Tests/i18n.Domain.Tests.csproj
@@ -8,7 +8,6 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>i18n.Domain.Tests</RootNamespace>
     <AssemblyName>i18n.Domain.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
@@ -58,6 +57,10 @@
     <ProjectReference Include="..\i18n.Domain\i18n.Domain.csproj">
       <Project>{bc2104ab-dc34-45b3-ab4d-3035f11fbdb8}</Project>
       <Name>i18n.Domain</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\i18n\i18n.csproj">
+      <Project>{E7A9BBA3-8A95-492C-8806-4DE63C1DBA06}</Project>
+      <Name>i18n</Name>
     </ProjectReference>
   </ItemGroup>
   <Choose>

--- a/src/i18n.Domain/Helpers/NuggetParser.cs
+++ b/src/i18n.Domain/Helpers/NuggetParser.cs
@@ -134,7 +134,7 @@ namespace i18n.Helpers
            // Prep the regexes. We escape each token char to ensure it is not misinterpreted.
            // · Breakdown e.g. "\[\[\[(.+?)(?:\|\|\|(.+?))*(?:\/\/\/(.+?))?\]\]\]"
             m_regexNuggetBreakdown = new Regex(
-                string.Format(@"{0}(.+?)(?:{1}(.+?))*(?:{2}(.+?))?{3}",
+                string.Format(@"{0}(.+?)(?:{1}(.*?))*(?:{2}(.+?))?{3}",
                     EscapeString(m_nuggetTokens.BeginToken), 
                     EscapeString(m_nuggetTokens.DelimiterToken), 
                     EscapeString(m_nuggetTokens.CommentToken), 
@@ -229,8 +229,6 @@ namespace i18n.Helpers
                 n.FormatItems = new string[formatItems.Count];
                 int i = 0;
                 foreach (Capture capture in formatItems) {
-                    if (!capture.Value.IsSet()) {
-                        return null; } // bad format
                     n.FormatItems[i++] = capture.Value;
                 }
             }


### PR DESCRIPTION
I had to downgrade the testproject from .NET v4.5 to v4.0 since I'm using Visual Studio 2010; all tests still pass. The reference i18n.Domain.Tests to i18n is required for `NuggetLocalizer.ConvertIdentifiersInMsgId`, should this method perhaps be moved to the i18n.Domain project instead?
