### PR TITLE
Bug fix: First token on first page load for a language is not translated

### DIFF
--- a/src/i18n/TextLocalizer.cs
+++ b/src/i18n/TextLocalizer.cs
@@ -225,6 +225,7 @@ namespace i18n
 			if (messages == null)
 			{
 				LoadMessagesIntoCache(langtag);
+                messages = (ConcurrentDictionary<string, TranslationItem>)HttpRuntime.Cache[GetCacheKey(langtag)];
 			}
 
             if (messages == null


### PR DESCRIPTION
When a page gets loaded and the HttpRuntime cache is empty, the LookupText function will populate it on a per language basis.  

The first token for a language pays the price of inserting a translation into the cache, but it doesn't update the messages variable.  It continues to be null on the first call to LookupText for a language.

I added one line to populate the messages variable _after_ the cache has been updated. 

Kept noticing this bug when testing locally and hopefully this is an ok way to fix it.  
