### PR TITLE
Write relative paths instead of absolute paths in .pot- and .po-files.

### DIFF
--- a/src/i18n.Domain/Concrete/FileNuggetFinder.cs
+++ b/src/i18n.Domain/Concrete/FileNuggetFinder.cs
@@ -76,7 +76,7 @@ namespace i18n.Domain.Concrete
                                 if (Path.GetExtension(filePath) == whiteListItem.Substring(1))
                                 {
                                     //we got a match
-                                    ParseFile(filePath, templateItems);
+                                    ParseFile(_settings.ProjectDirectory, filePath, templateItems);
                                     break;
                                 }
                             }
@@ -85,7 +85,7 @@ namespace i18n.Domain.Concrete
                                 if (Path.GetFileName(filePath) == whiteListItem)
                                 {
                                     //we got a match
-                                    ParseFile(filePath, templateItems);
+                                    ParseFile(_settings.ProjectDirectory, filePath, templateItems);
                                     break;
                                 }
                             }
@@ -98,8 +98,12 @@ namespace i18n.Domain.Concrete
 			return templateItems;
 		}
 
-		private void ParseFile(string filePath, ConcurrentDictionary<string, TemplateItem> templateItems)
+		private void ParseFile(string projectDirectory, string filePath, ConcurrentDictionary<string, TemplateItem> templateItems)
         {
+            var referencePath = (projectDirectory != null) && filePath.StartsWith(projectDirectory, StringComparison.OrdinalIgnoreCase)
+                ? filePath.Substring(projectDirectory.Length + 1)
+                : filePath;
+
             DebugHelpers.WriteLine("FileNuggetFinder.ParseFile -- {0}", filePath);
            // Lookup any/all nuggets in the file and for each add a new template item.
 			using (var fs = File.OpenText(filePath))
@@ -107,7 +111,7 @@ namespace i18n.Domain.Concrete
                 _nuggetParser.ParseString(fs.ReadToEnd(), delegate(string nuggetString, int pos, Nugget nugget, string i_entity)
                 {
 				    AddNewTemplateItem(
-                        filePath, 
+                        referencePath, 
                         i_entity.LineFromPos(pos), 
                         nugget, 
                         templateItems);

--- a/src/i18n.Domain/Concrete/i18nSettings.cs
+++ b/src/i18n.Domain/Concrete/i18nSettings.cs
@@ -19,11 +19,14 @@ namespace i18n.Domain.Concrete
 			_settingService = settings;
 		}
 
+	    public String ProjectDirectory {
+	        get { return Path.GetDirectoryName(_settingService.GetConfigFileLocation()); }
+	    }
+
 		private string GetPrefixedString(string key)
 		{
 			return _prefix + key;
 		}
-
 
 		private string MakePathAbsoluteAndFromConfigFile(string path)
 		{


### PR DESCRIPTION
Currently both .pot- and .po-files get absolute paths (`#: C:\Dev\src\ProjectName\Views\Layout.cshtml:123`) which differs between developers in our project. These proposed changes will persist a relative path, based on the location of the web.config file passed to the postbuild tool, resulting in `#: Views\Layout.cshtml:123`
