### PR TITLE
create the default QuickUrlExclusionFilter Regex with RegexOption.Compiled

### DIFF
--- a/src/i18n/UrlLocalizer.cs
+++ b/src/i18n/UrlLocalizer.cs
@@ -98,7 +98,7 @@ namespace i18n
         /// <remarks>
         /// This filtering in performed in addition to any custom IncomingUrlFilters/OutgoingUrlFilters filters.
         /// </remarks>
-        public static Regex QuickUrlExclusionFilter = new System.Text.RegularExpressions.Regex(@"(?:sitemap\.xml|\.css|\.jpg|\.png|\.svg|\.woff|\.eot)$");
+        public static Regex QuickUrlExclusionFilter = new System.Text.RegularExpressions.Regex(@"(?:sitemap\.xml|\.css|\.jpg|\.png|\.svg|\.woff|\.eot)$", RegexOptions.Compiled);
 
         /// <summary>
         /// Filters that examines the request URL during Early URL Localization


### PR DESCRIPTION
Description of improvement found from a quick googling:

http://stackoverflow.com/questions/513412/how-does-regexoptions-compiled-work

This will result in slower execution of the UrlLocalizer static constructor but long-term performance benefits at runtime should outweigh that handily.