### PR TITLE
Exclude URLs from processing

### DIFF
--- a/src/i18n/LocalizedApplication.cs
+++ b/src/i18n/LocalizedApplication.cs
@@ -152,6 +152,18 @@ namespace i18n
         ///      zero or more whitespace then ";" then any number of any chars up to end of string.
         /// </remarks>
         public Regex ContentTypesToLocalize = new Regex(@"^(?:(?:(?:text|application)/(?:plain|html|xml|javascript|x-javascript|json|x-json))(?:\s*;.*)?)$");
+
+        /// <summary>
+        /// Regular expression that excludes certain URL paths from being localized.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to excluding all less and css files and any URLs containing the phrases i18nSkip, glimpse, trace or elmah (case-insensitive)<br/>
+        /// Clients may customise this member in Application_Start<br/>
+        /// This feature requires the LocalizedModule HTTP module to be intalled in web.config.<br/>
+        /// </remarks>
+        public Regex UrlsToExcludeFromProcessing = new Regex(@"(?:\.(?:less|css)(?:\?|$))|(?i:i18nSkip|glimpse|trace|elmah)");
+
+
         public LocalizedApplication()
         {
             Container = new Container();

--- a/src/i18n/LocalizingModule.cs
+++ b/src/i18n/LocalizingModule.cs
@@ -95,17 +95,24 @@ namespace i18n
             HttpContextBase context = HttpContext.Current.GetHttpContextBase();
             DebugHelpers.WriteLine("LocalizingModule::OnReleaseRequestState -- sender: {0}, e:{1}, ContentType: {2},\n+++>Url: {3}\n+++>RawUrl:{4}", sender, e, context.Response.ContentType, context.Request.Url, context.Request.RawUrl);
 
-            // If the content type of the entity is eligible for processing...wire up our filter
-            // to do the processing. The entity data will be run through the filter a bit later on
-            // in the pipeline.
-            if (LocalizedApplication.Current.ContentTypesToLocalize != null
-                && LocalizedApplication.Current.ContentTypesToLocalize.Match(context.Response.ContentType).Success) {
+            // If the content type of the entity is eligible for processing AND the URL is not to be excluded,
+            // wire up our filter to do the processing. The entity data will be run through the filter a
+            // bit later on in the pipeline.
+            if ((LocalizedApplication.Current.ContentTypesToLocalize != null
+                    && LocalizedApplication.Current.ContentTypesToLocalize.Match(context.Response.ContentType).Success) // Include certain content types from being processed
+                &&
+                (LocalizedApplication.Current.UrlsToExcludeFromProcessing != null
+                    && LocalizedApplication.Current.UrlsToExcludeFromProcessing.Match(context.Request.RawUrl).Success) == false) // Exclude certain URLs from being processed
+                {
                 DebugHelpers.WriteLine("LocalizingModule::OnReleaseRequestState -- Installing filter");
                 context.Response.Filter = new ResponseFilter(
                     context, 
                     context.Response.Filter,
                     m_rootServices.EarlyUrlLocalizerForApp,
                     m_rootServices.NuggetLocalizerForApp);
+                }
+            else {
+                DebugHelpers.WriteLine("LocalizingModule::OnReleaseRequestState -- No content-type match ({0}). Bypassing filter.",context.Response.ContentType);
             }
         }
     }


### PR DESCRIPTION
This adds the ability for the module to exclude URLs matching a Regex from being processed. I am using this to prevent the Glimpse.axd files from being processed, as the i18n module currently breaks Glimpse.

In addition, you can add ?i18nSkip to the URL and you'll see your original page without the nuggets being processed. I find this very useful for
- checking how I've defined my nuggets, particularly those that make substitutions
- some admin screens where I define nuggets that are stored in a database

I'm afraid this is my first ever pull request on GitHub so I'm not sure if I've done it right, of if this is even welcome!

Also there are a load of other changes I made but have reverted - but I can't get rid of the trace of them.
