### PR TITLE
Ignore blacklisted subdirs

### DIFF
--- a/src/i18n.Domain/Concrete/FileNuggetFinder.cs
+++ b/src/i18n.Domain/Concrete/FileNuggetFinder.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Text;
 using i18n.Domain.Abstract;
 using i18n.Domain.Entities;
+using i18n.Domain.Helpers;
 using i18n.Helpers;
 
 namespace i18n.Domain.Concrete
@@ -35,6 +36,7 @@ namespace i18n.Domain.Concrete
 		{
 			IEnumerable<string> fileWhiteList = _settings.WhiteList;
 			IEnumerable<string> directoriesToSearchRecursively = _settings.DirectoriesToScan;
+            FileEnumerator fileEnumerator = new FileEnumerator(_settings.BlackList);
 
 			string currentFullPath;
 			bool blacklistFound = false;
@@ -44,7 +46,7 @@ namespace i18n.Domain.Concrete
 
 			foreach (var directoryPath in directoriesToSearchRecursively)
 			{
-				foreach (string filePath in Directory.EnumerateFiles(directoryPath, "*.*", SearchOption.AllDirectories))
+                foreach (string filePath in fileEnumerator.GetFiles(directoryPath))
 				{
                     if (filePath.Length >= 260)
                     {

--- a/src/i18n.Domain/Helpers/FileEnumerator.cs
+++ b/src/i18n.Domain/Helpers/FileEnumerator.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace i18n.Domain.Helpers
+{
+    public class FileEnumerator
+    {
+        private readonly IEnumerable<string> _blackList;
+
+        public FileEnumerator(IEnumerable<string> blackList)
+        {
+            _blackList = blackList;
+            foreach (string str in blackList)
+                Console.WriteLine(str);
+        }
+
+        public IEnumerable<string> GetFiles(string path)
+        {
+            Queue<string> queue = new Queue<string>();
+            queue.Enqueue(path);
+            while (queue.Count > 0)
+            {
+                path = queue.Dequeue();
+                try
+                {
+                    foreach (string path1 in Directory.EnumerateDirectories(path))
+                    {
+                        if (!IsBlackListed(path1))
+                            queue.Enqueue(path1);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine(ex);
+                }
+                IEnumerable<string> files = null;
+                try
+                {
+                    files = Directory.EnumerateFiles(path, "*.*", SearchOption.TopDirectoryOnly);
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine((object)ex);
+                }
+                if (files != null)
+                {
+                    foreach (string path1 in files)
+                    {
+                        if (!IsBlackListed(path1))
+                            yield return path1;
+                    }
+                }
+            }
+        }
+
+        private bool IsBlackListed(string path)
+        {
+            return _blackList.Any(x => path.StartsWith(x, StringComparison.OrdinalIgnoreCase));
+        }
+    }
+}

--- a/src/i18n.Domain/i18n.Domain.csproj
+++ b/src/i18n.Domain/i18n.Domain.csproj
@@ -62,6 +62,7 @@
     <Compile Include="Entities\TemplateItem.cs" />
     <Compile Include="Entities\TranslationItem.cs" />
     <Compile Include="Entities\Translation.cs" />
+    <Compile Include="Helpers\FileEnumerator.cs" />
     <Compile Include="Helpers\MiscHelpers.cs" />
     <Compile Include="Helpers\CollectionExtensions.cs" />
     <Compile Include="Helpers\DebugHelpers.cs" />


### PR DESCRIPTION
When scanning for nuggets, subdirectories of blacklisted directories are still visited. This is a problem when using node_modules, because the depth of the directory tree can be quite extreme (nested modules in nested modules).

My take on this is that when we scan for nuggets, and gets in a blacklisted directory, we skip all folders below.

Ps. this is my very first pull request, so please let me know if I can do any thing to make it better. ds.