### PR TITLE
Handle missing cultures and invalid user language

### DIFF
--- a/src/i18n.Domain/Concrete/POTranslationRepository.cs
+++ b/src/i18n.Domain/Concrete/POTranslationRepository.cs
@@ -54,9 +54,17 @@ namespace i18n.Domain.Concrete
 				
 				foreach (var dir in di.EnumerateDirectories().Select(x => x.Name))
 				{
-					lang = new Language();
-					lang.LanguageShortTag = dir;
-					dirList.Add(lang);
+					try
+					{
+						System.Globalization.CultureInfo.GetCultureInfo(dir);
+						lang = new Language();
+						lang.LanguageShortTag = dir;
+						dirList.Add(lang);
+					}
+					catch (System.Globalization.CultureNotFoundException) 
+					{ 
+						//There is a directory in the locale directory that is not a valid culture so ignore it
+					}
 				}
 			}
 			else

--- a/src/i18n/Helpers/LanguageItem.cs
+++ b/src/i18n/Helpers/LanguageItem.cs
@@ -165,6 +165,9 @@ namespace i18n
            // Truncate any extra elements from end of array.
             if (ordinal != LanguageItems.Length) {
                 LanguageItems = LanguageItems.Where(x => x.LanguageTag.IsValid()).ToArray(); }
+            // If there was no PAL, and the header value was invalid then we will have no language items, so add the default
+            if (LanguageItems.Length == 0)
+                LanguageItems = new LanguageItem[] { new LanguageItem(LocalizedApplication.Current.DefaultLanguageTag, PalQualitySetting, 0) };
            // Rearrange items into order of precedence. This is facilitated by LanguageItem's
            // impl. of IComparable.
             Array.Sort(LanguageItems);


### PR DESCRIPTION
When the list of directories is used to get the list of languages a missing culture or directory that is not a culture will cause an error that prevents all the other languages from loading so check each directory as it is added.

Secondly, handle the case where the language in the user request is invalid and no PAL has been configured.