### PR TITLE
Add check for async postbacks

### DIFF
--- a/src/i18n/Pipeline/ResponseFilter.cs
+++ b/src/i18n/Pipeline/ResponseFilter.cs
@@ -89,8 +89,14 @@ namespace i18n
             if (m_nuggetLocalizer != null)
             {
                 var page = m_httpContext.Handler as Page;
+                bool isScriptManager = false;
+                if (page != null)
+                {
+                    var sm = ScriptManager.GetCurrent(page);
+                    if (sm != null && sm.IsInAsyncPostBack) isScriptManager = true;
+                }
                 //if webforms and postback
-                if (page != null && page.IsPostBack && !String.IsNullOrEmpty(entity) && !String.IsNullOrEmpty(entity.Replace("\r","").Split('\n')[0])) { //#178
+                if (page != null && page.IsPostBack && isScriptManager && !String.IsNullOrEmpty(entity) && !String.IsNullOrEmpty(entity.Replace("\r","").Split('\n')[0])) { //#178
                     var postbackParser = new PostbackParser(entity);
                     // not quite sure only those 2 types should be translated (any help ?)
                     var types = new[]

--- a/src/i18n/i18n.csproj
+++ b/src/i18n/i18n.csproj
@@ -52,6 +52,7 @@
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Core" />
     <Reference Include="System.Web" />
+    <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />


### PR DESCRIPTION
This is a fix for issue #188. The response filter creates a
PostbackParser instance for all postbacks, but it should only create the
PostbackParser instance for async Ajax postbacks, otherwise regular page
postbacks are parsed unnecessarily and can even cause the entire page to
cause an exception (this happens if the page has a pipe symbol anywhere
in the content). This change adds a test so that the PostbackParser
instance is only created for async Ajax postbacks.

Two further considerations:
1. Making this even more robust and check that actual formatting of the
postback.
2. Rename PostbackParser because the parser does not parse all
postbacks, rather only async Ajax postbacks.