### PR TITLE
Added two optional message visualization params

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,25 @@ To enable this feature:
 When VisualizeMessages is active the NuggetVisualizeToken will be inserted at start and end of
 each translated message.   
 
+Two more optional parameters can be used to further customize the message visualization. 
+`i18n.VisualizeLanguageSeparator`
+This enables display of the language tag that was use to localize each message. The language tag will be shown before each message, separated from the message by this parameter value. If the value is a blank string or the parameter is not present then language tags are not shown in message visualizations.
+`i18n.NuggetVisualizeEndToken`
+This allows for using different start and end tokens for visualizing messages. When this value is specified then the NuggetVisualizeToken will be inserted at start of each translated message and the NuggetVisualizeEndToken will be inserted at end of each translated message.
+
+For example, to display language tags separated from messages by a colon, and add brackets to enclose the visualized messages, use the following message visualization configuration.
+
+```xml
+  <appSettings>
+    ...
+    <add key="i18n.VisualizeMessages" value="true" />
+    <add key="i18n.VisualizeLanguageSeparator" value=":" />
+    <add key="i18n.NuggetVisualizeToken" value="![" />
+    <add key="i18n.NuggetVisualizeEndToken" value="]!" />
+    ...
+  </appSettings>
+```
+
 #### Message Context Support
 
 i18n allows you to assign a ```msgctxt``` value to each message. The value of the msgctxt is

--- a/src/i18n.Domain/Concrete/i18nSettings.cs
+++ b/src/i18n.Domain/Concrete/i18nSettings.cs
@@ -326,6 +326,25 @@ namespace i18n.Domain.Concrete
             }
         }
 
+        public virtual string NuggetVisualizeEndToken
+        {
+            get
+            {
+                string prefixedString = GetPrefixedString("NuggetVisualizeEndToken");
+                string setting = _settingService.GetSetting(prefixedString);
+                if (setting != null)
+                {
+                    return setting;
+                }
+                return string.Empty;
+            }
+            set
+            {
+                string prefixedString = GetPrefixedString("NuggetVisualizeEndToken");
+                _settingService.SetSetting(prefixedString, value);
+            }
+        }
+
 		#endregion
         
 		#region DirectoriesToScan
@@ -461,6 +480,25 @@ namespace i18n.Domain.Concrete
                 string prefixedString = GetPrefixedString("VisualizeMessages");
                 _settingService.SetSetting(prefixedString, value ? "true" : "false");
                 _cached_visualizeMessages = value;
+            }
+        }
+
+        public virtual string VisualizeLanguageSeparator
+        {
+            get
+            {
+                string prefixedString = GetPrefixedString("VisualizeLanguageSeparator");
+                string setting = _settingService.GetSetting(prefixedString);
+                if (setting != null)
+                {
+                    return setting;
+                }
+                return string.Empty;
+            }
+            set
+            {
+                string prefixedString = GetPrefixedString("VisualizeLanguageSeparator");
+                _settingService.SetSetting(prefixedString, value);
             }
         }
 

--- a/src/i18n/Concrete/NuggetLocalizer.cs
+++ b/src/i18n/Concrete/NuggetLocalizer.cs
@@ -94,7 +94,15 @@ namespace i18n
                 DebugHelpers.WriteLine("I18N.NuggetLocalizer.ProcessNuggets -- msgid: {0,35}, message: {1}", nugget.MsgId, message);
 
                 if (_settings.VisualizeMessages)
-                    message = string.Format("{0}{1}{0}", _settings.NuggetVisualizeToken, message);
+                {
+                    string languageToken = string.Empty;
+                    if (!string.IsNullOrWhiteSpace(_settings.VisualizeLanguageSeparator))
+                        languageToken = lt.ToString() + _settings.VisualizeLanguageSeparator;
+                    string endToken = _settings.NuggetVisualizeToken;
+                    if (!string.IsNullOrWhiteSpace(_settings.NuggetVisualizeEndToken))
+                        endToken = _settings.NuggetVisualizeEndToken;
+                    message = string.Format("{0}{1}{2}{3}", _settings.NuggetVisualizeToken, languageToken, message, endToken);
+                }
                 return HttpUtility.HtmlDecode(message);
             });
            // Return modified entity.


### PR DESCRIPTION
I have added two new params to allow message visualization to display the selected language tag that was used in each message translation, and also to allow for the start and end tokens to be different. I intentionally did not change the existing params, so that this is a non-breaking change, the new params are optional and if they are not specified then the behavior will be unchanged.

If used a translated message could now be displayed something like this:
`![en:My message]!`
or
`![es-MX:Mi mensaje]!`