### PR TITLE
Fixes for issues with corrupt responses

### DIFF
--- a/src/i18n/Helpers/DebugHelpers.cs
+++ b/src/i18n/Helpers/DebugHelpers.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 using System.Text;
+using System.Threading;
 
 namespace i18n.Helpers
 {
@@ -9,18 +10,20 @@ namespace i18n.Helpers
         [Conditional("DEBUG")]
         public static void WriteLine(string message)
         {
-            string str = String.Format("+++> {0} -- {1}",
+            string str = String.Format("+++> {0}, Thread ID: {1} -- {2}",
                 DateTime.Now.ToString(),
+                Thread.CurrentThread.ManagedThreadId,
                 message);
             Debug.WriteLine(str);
         }
         [Conditional("DEBUG")]
         public static void WriteLine(string format, params object[] args)
         {
-            string str = String.Format("+++> {0} -- {1}",
+            string str = String.Format("+++> {0}, Thread ID: {1} -- {2}",
                 DateTime.Now.ToString(),
+                Thread.CurrentThread.ManagedThreadId,
                 format);
-            Debug.WriteLine(str, args);
+            Debug.WriteLine(string.Format(str, args));
         }
     }
 }

--- a/src/i18n/Pipeline/LocalizingModule.cs
+++ b/src/i18n/Pipeline/LocalizingModule.cs
@@ -70,7 +70,7 @@ namespace i18n
         private void OnBeginRequest(object sender, EventArgs e)
         {
             HttpContextBase context = HttpContext.Current.GetHttpContextBase();
-            DebugHelpers.WriteLine("LocalizingModule::OnBeginRequest -- sender: {0}, e:{1}, ContentType: {2},\n+++>Url: {3}\n+++>RawUrl:{4}", sender, e, context.Response.ContentType, context.Request.Url, context.Request.RawUrl);
+            DebugHelpers.WriteLine("LocalizingModule::OnBeginRequest -- sender: {0}, e:{1}, ContentType: {2},\n\tUrl: {3}\n\tRawUrl:{4}", sender, e, context.Response.ContentType, context.Request.Url, context.Request.RawUrl);
 
             // Establish the language for the request. That is, we need to call
             // context.SetPrincipalAppLanguageForRequest with a language, got from the URL,
@@ -94,26 +94,39 @@ namespace i18n
         {
         //
             HttpContextBase context = HttpContext.Current.GetHttpContextBase();
-            DebugHelpers.WriteLine("LocalizingModule::OnReleaseRequestState -- sender: {0}, e:{1}, ContentType: {2},\n+++>Url: {3}\n+++>RawUrl:{4}", sender, e, context.Response.ContentType, context.Request.Url, context.Request.RawUrl);
+            DebugHelpers.WriteLine("LocalizingModule::OnReleaseRequestState -- sender: {0}, e:{1}, ContentType: {2},\n\tUrl: {3}\n\tRawUrl:{4}", sender, e, context.Response.ContentType, context.Request.Url, context.Request.RawUrl);
 
             // If the content type of the entity is eligible for processing AND the URL is not to be excluded,
             // wire up our filter to do the processing. The entity data will be run through the filter a
             // bit later on in the pipeline.
             if ((LocalizedApplication.Current.ContentTypesToLocalize != null
                     && LocalizedApplication.Current.ContentTypesToLocalize.Match(context.Response.ContentType).Success) // Include certain content types from being processed
-                &&
-                (LocalizedApplication.Current.UrlsToExcludeFromProcessing != null
-                    && LocalizedApplication.Current.UrlsToExcludeFromProcessing.Match(context.Request.RawUrl).Success) == false) // Exclude certain URLs from being processed
+                    )
+            {
+                if ((LocalizedApplication.Current.UrlsToExcludeFromProcessing != null
+                    && LocalizedApplication.Current.UrlsToExcludeFromProcessing.Match(context.Request.RawUrl).Success) // Exclude certain URLs from being processed
+                    )
                 {
-                DebugHelpers.WriteLine("LocalizingModule::OnReleaseRequestState -- Installing filter");
-                context.Response.Filter = new ResponseFilter(
-                    context, 
-                    context.Response.Filter,
-                    UrlLocalizer.UrlLocalizationScheme == UrlLocalizationScheme.Void ? null : m_rootServices.EarlyUrlLocalizerForApp,
-                    m_rootServices.NuggetLocalizerForApp);
+                    DebugHelpers.WriteLine("LocalizingModule::OnReleaseRequestState -- Bypassing filter, URL excluded: ({0}).", context.Request.RawUrl);
                 }
+                else if ((context.Response.Headers["Content-Encoding"] != null
+                    || context.Response.Headers["Content-Encoding"] == "gzip") // Exclude responses that have already been compressed earlier in the pipeline
+                )
+                {
+                    DebugHelpers.WriteLine("LocalizingModule::OnReleaseRequestState -- Bypassing filter, response compressed.");
+                }
+                else
+                {
+                    DebugHelpers.WriteLine("LocalizingModule::OnReleaseRequestState -- Installing filter");
+                    context.Response.Filter = new ResponseFilter(
+                        context,
+                        context.Response.Filter,
+                        UrlLocalizer.UrlLocalizationScheme == UrlLocalizationScheme.Void ? null : m_rootServices.EarlyUrlLocalizerForApp,
+                        m_rootServices.NuggetLocalizerForApp);
+                }
+            }
             else {
-                DebugHelpers.WriteLine("LocalizingModule::OnReleaseRequestState -- No content-type match ({0}). Bypassing filter.",context.Response.ContentType);
+                DebugHelpers.WriteLine("LocalizingModule::OnReleaseRequestState -- Bypassing filter, No content-type match: ({0}).", context.Response.ContentType);
             }
         }
     }


### PR DESCRIPTION
These commits deal with two known issues:

1. When a response gets compressed earlier in the pipeline then i18n has been corrupting the response (generally resulting in the ERR_CONTENT_DECODING_FAILED error seen on Chrome). I am pretty sure that this is because the compressed data coming into the stream is copied to the MemoryStream and then encoded with the UTF-8 encoding, you can't do that with compressed data, which is a binary stream. When the encoded string is then rewritten to the output stream it is no longer a valid copy of the original binary compressed bytes and the response stream is no longer valid gzip content, so the client cannot decompress it.
That being the case, the i18n module needs to detect when the incoming data is compressed and do nothing to it. I have added two checks to prevent this corruption - first, I have found that although the Response.ContentEncoding will be set to UTF-8, if the response is compressed, then then Content-Encoding header in the Response will be set to gzip, I'm checking for that in LocalizingModule and do not install the filter if that is true. Secondly I am checking for the two bytes at the beginning of the input stream that identify the content as gzip compressed (1F 8B), if they are found I set a private flag in ResponseFilter and then pass the content through unchanged when the flag is set.

This does not allow the i18n module to localize content that has already been compressed but I don't think that needs to be a goal of the module - if someone wants to localize static files then they can turn off static file compression, or they must put the content into files/handlers that are dynamic. The key thing is to have the module reliably do nothing when the incoming stream is already compressed - if anyone else has examples of content types/scenarios where errors still occur please add them to this issue and I'll try to add more tests to exclude the compressed content from being touched by the module.

2. Prevent empty responses to requests for WebResource.axd - this is a legacy tech, but it's relatively simple to have i18n play nicely so I added the fix. The fix is discussed in various forums and involves using reflection. I would suggest that WebResource.axd and ScriptResource.axd can be added to the default list of excluded URLs because I don't think it would be a good idea to localize either of them anyway, but this fix makes sure that i18n doesn't break WebResource.axd if someone does leave it being localized.

I have not done extensive testing with these changes in an MVC environment, but they are working well in development in a fairly large web application that does use lots of content types.