### PR TITLE
Optionally show source context next to reference paths & line numbers

### DIFF
--- a/src/i18n.Domain.Tests/PathNormalizerTests.cs
+++ b/src/i18n.Domain.Tests/PathNormalizerTests.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.IO;
+using i18n.Domain.Helpers;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace i18n.Domain.Tests
+{
+    [TestClass]
+    public class PathNormalizerTests
+    {
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void MakeRelativePath_InvalidPath_Throws()
+        {
+            var anchorPath = string.Empty;
+            PathNormalizer.MakeRelativePath(anchorPath, null);
+        }
+
+        [TestMethod]
+        public void MakeRelativePath_NullOrEmptyAnchorPath_ReturnsPath()
+        {
+            var path = @"C:\some\path\file.ext";
+
+            AssertNormalizedPath(null, path, path, "Null anchor path");
+            AssertNormalizedPath(string.Empty, path, path, "Empty anchor path");
+        }
+
+        private static void AssertNormalizedPath(string anchorPath, string path, string expected, string reason)
+        {
+            var actual = PathNormalizer.MakeRelativePath(anchorPath, path);
+
+            Assert.AreEqual(expected, actual, reason);
+        }
+
+        [TestMethod]
+        public void MakeRelativePath_SimpleRelativePath_ReturnsRelativePath()
+        {
+            var anchorPath = @"C:\Some\Path";
+            var relativePath = @"Another\Nested\File.ext";
+            var path = Path.Combine(anchorPath, relativePath);
+
+            AssertNormalizedPath(anchorPath, path, relativePath, "Simple relative path");
+        }
+
+        [TestMethod]
+        public void MakeRelativePath_NoCommonPortion_ReturnsPath()
+        {
+            var anchorPath = @"C:\Some\Path";
+            var path = @"D:\Some\Other\Path";
+            AssertNormalizedPath(anchorPath, path, path, "No common path portion");
+        }
+
+        [TestMethod]
+        public void MakeRelativePath_SomeCommonPorths_ReturnsRelativePath()
+        {
+            var commonPath = @"C:\Some\Common\Path";
+            var anchorPath = Path.Combine(commonPath, @"Anchor\Path");
+            var distinctPath = @"Distinct\Path\File.ext";
+            var path = Path.Combine(commonPath, distinctPath);
+            var relativePath = Path.Combine(@"..\..", distinctPath);
+            AssertNormalizedPath(anchorPath, path, relativePath, "Some common path components");
+        }
+    }
+}

--- a/src/i18n.Domain.Tests/ReferenceContextTests.cs
+++ b/src/i18n.Domain.Tests/ReferenceContextTests.cs
@@ -1,0 +1,65 @@
+﻿using i18n.Domain.Entities;
+using i18n.Domain.Helpers;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace i18n.Domain.Tests
+{
+    [TestClass]
+    public class ReferenceContextTests
+    {
+        private const string Path = @"C:\Some\Path\File.ext";
+        private const string Content =
+        //   0          1          2           3         4           5
+        //   0123456789 0 12345678901 2 345678901234567890 1 234567890123456789
+            "The quick\r\n brown fox\r\n jumps over the lazy \r\ndog";
+
+        [TestMethod]
+        public void Create_PositionTooSmall_ReturnsFirstLine()
+        {
+            AssertExpectedContext(-10, CreateExpected("The quick", 1), "Position too small");
+        }
+
+        [TestMethod]
+        public void Create_WithOutOfRangePosition_ReturnsLastLineWithNoContext()
+        {
+            AssertExpectedContext(Content.Length + 10, CreateExpected(string.Empty, 4), "Position too big");
+        }
+
+        [TestMethod]
+        public void Create_PositionInFirstLine_ReturnsFirstLine()
+        {
+            AssertExpectedContext(2, CreateExpected("The quick", 1), "Position in first line");
+        }
+
+        [TestMethod]
+        public void Create_PositionInThirdLine_ReturnsThirdLine()
+        {
+            AssertExpectedContext(23, CreateExpected("jumps over the lazy", 3), "Position in 3rd line");
+        }
+
+        [TestMethod]
+        public void Create_PositionInLastLine_ReturnsLastLine()
+        {
+            AssertExpectedContext(46, CreateExpected("dog", 4), "Position in last line");
+        }
+
+        private static ReferenceContext CreateExpected(string context, int lineNumber)
+        {
+            return new ReferenceContext
+            {
+                Path = Path,
+                LineNumber = lineNumber,
+                Context = context
+            };
+        }
+
+        private static void AssertExpectedContext(int position, ReferenceContext expected, string reason)
+        {
+            var actual = ReferenceContext.Create(Path, Content, position);
+
+            Assert.AreEqual(expected.Path, actual.Path, "Path: " + reason);
+            Assert.AreEqual(expected.LineNumber, actual.LineNumber, "LineNumber: " + reason);
+            Assert.AreEqual(expected.Context, actual.Context, "Context:" + reason);
+        }
+    }
+}

--- a/src/i18n.Domain.Tests/i18n.Domain.Tests.csproj
+++ b/src/i18n.Domain.Tests/i18n.Domain.Tests.csproj
@@ -50,8 +50,10 @@
   </Choose>
   <ItemGroup>
     <Compile Include="NuggetTests.cs" />
+    <Compile Include="PathNormalizerTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="NuggetParserTests.cs" />
+    <Compile Include="ReferenceContextTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\i18n.Domain\i18n.Domain.csproj">

--- a/src/i18n.Domain/Concrete/POTranslationRepository.cs
+++ b/src/i18n.Domain/Concrete/POTranslationRepository.cs
@@ -224,7 +224,7 @@ namespace i18n.Domain.Concrete
 						foreach (var reference in item.References)
 						{
 							hasReferences = true;
-							stream.WriteLine("#: " + reference);
+							stream.WriteLine("#: " + reference.ToComment());
 						}
 					}
 
@@ -320,7 +320,7 @@ namespace i18n.Domain.Concrete
 
 					foreach (var reference in item.References)
 					{
-						stream.WriteLine("#: " + reference);
+						stream.WriteLine("#: " + reference.ToComment());
 					}
 
                     if (_settings.MessageContextEnabledFromComment
@@ -383,10 +383,10 @@ namespace i18n.Domain.Concrete
 				    bool itemStarted = false;
 				    while ((line = fs.ReadLine()) != null)
 				    {
-					    List<string> extractedComments = new List<string>();
-					    List<string> translatorComments = new List<string>();
-					    List<string> flags = new List<string>();
-					    List<string> references = new List<string>();
+					    var extractedComments = new List<string>();
+					    var translatorComments = new List<string>();
+					    var flags = new List<string>();
+					    var references = new List<ReferenceContext>();
 
 					    //read all comments, flags and other descriptive items for this string
 					    //if we have #~ its a historical/log entry but it is the messageID/message so we skip this do/while
@@ -401,7 +401,7 @@ namespace i18n.Domain.Concrete
 									    extractedComments.Add(line.Substring(2).Trim());
 									    break;
 								    case ':': //references
-									    references.Add(line.Substring(2).Trim());
+									    references.Add(ReferenceContext.Parse(line.Substring(2).Trim()));
 									    break;
 								    case ',': //flags
 									    flags.Add(line.Substring(2).Trim());
@@ -435,9 +435,10 @@ namespace i18n.Domain.Concrete
                                     // Update routine.
                                     (k, v) => {
                                         v.References = v.References.Append(item.References);
-                                        v.ExtractedComments = v.ExtractedComments.Append(item.References);
-                                        v.TranslatorComments = v.TranslatorComments.Append(item.References);
-                                        v.Flags = v.Flags.Append(item.References);
+                                        var referencesAsComments = item.References.Select(r => r.ToComment()).ToList();
+                                        v.ExtractedComments = v.ExtractedComments.Append(referencesAsComments);
+                                        v.TranslatorComments = v.TranslatorComments.Append(referencesAsComments);
+                                        v.Flags = v.Flags.Append(referencesAsComments);
                                         return v;
                                     });
                             }

--- a/src/i18n.Domain/Entities/ReferenceContext.cs
+++ b/src/i18n.Domain/Entities/ReferenceContext.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Text.RegularExpressions;
+
+namespace i18n.Domain.Entities
+{
+    public class ReferenceContext
+    {
+        public static bool ShowSourceContext { get; set; }
+
+        public string Path { get; set; }
+        public int LineNumber { get; set; }
+        public string Context { get; set; }
+
+        public static ReferenceContext Create(string path, string content, int position)
+        {
+            var lineNumber = 1;
+            var lineStartPosition = 0;
+            var context = string.Empty;
+
+            for (var i = 0; i < content.Length; i++)
+            {
+                if (content[i] == '\n')
+                {
+                    lineNumber++;
+                    lineStartPosition = i;
+                }
+
+                if (i < position) continue;
+
+                var lineEndPosition = content.IndexOf("\n", i, StringComparison.Ordinal);
+
+                if (lineEndPosition < 0)
+                {
+                    lineEndPosition = content.Length;
+                }
+
+                context = content.Substring(lineStartPosition, lineEndPosition - lineStartPosition);
+                break;
+            }
+
+            return new ReferenceContext
+            {
+                Path = path,
+                LineNumber = lineNumber,
+                Context = context.Trim()
+            };
+        }
+
+        private static readonly Regex ReferenceRegex = new Regex(@"\s*(?<path>.*):(?<lineNumber>\d+)(?<context>.*)$", RegexOptions.Compiled);
+
+        public static ReferenceContext Parse(string line)
+        {
+            var match = ReferenceRegex.Match(line);
+
+            if (match.Success)
+            {
+                return new ReferenceContext
+                {
+                    Path = match.Groups["path"].Value.Trim(),
+                    LineNumber = Convert.ToInt32(match.Groups["lineNumber"].Value),
+                    Context = match.Groups["context"].Value.Trim()
+                };
+            }
+
+            return new ReferenceContext
+            {
+                Path = line
+            };
+        }
+
+        public string ToComment()
+        {
+            var comment = Path + ":" + LineNumber;
+
+            if (ShowSourceContext)
+            {
+                comment += " " + Context;
+            }
+
+            return comment;
+        }
+    }
+}

--- a/src/i18n.Domain/Entities/TemplateItem.cs
+++ b/src/i18n.Domain/Entities/TemplateItem.cs
@@ -15,7 +15,7 @@ namespace i18n.Domain.Entities
 	{
 		public string MsgKey;
         public string MsgId;
-		public IEnumerable<string> References { get; set; }
+		public IEnumerable<ReferenceContext> References { get; set; }
 		public IEnumerable<string> Comments { get; set; }
 
         public override string ToString()

--- a/src/i18n.Domain/Entities/TranslationItem.cs
+++ b/src/i18n.Domain/Entities/TranslationItem.cs
@@ -20,7 +20,7 @@ namespace i18n.Domain.Entities
 		public string MsgKey { get; set; }
 		public string MsgId { get; set; }
 		public string Message { get; set; }
-		public IEnumerable<string> References { get; set; }
+		public IEnumerable<ReferenceContext> References { get; set; }
 		public IEnumerable<string> ExtractedComments { get; set; }
 		public IEnumerable<string> TranslatorComments { get; set; }
 		public IEnumerable<string> Flags { get; set; }

--- a/src/i18n.Domain/Helpers/PathNormalizer.cs
+++ b/src/i18n.Domain/Helpers/PathNormalizer.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.IO;
+using System.Text;
+
+namespace i18n.Domain.Helpers
+{
+    public class PathNormalizer
+    {
+        private static readonly char[] PathSeparators = { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar };
+
+        public static string MakeRelativePath(string anchorPath, string path)
+        {
+            if (path == null)
+                throw new ArgumentNullException("path");
+
+            if (string.IsNullOrEmpty(anchorPath))
+                return path;
+
+            if (path.StartsWith(anchorPath, StringComparison.OrdinalIgnoreCase))
+            {
+                return path.Substring(anchorPath.Length + 1);
+            }
+
+            var anchorComponents = anchorPath.Split(PathSeparators, StringSplitOptions.RemoveEmptyEntries);
+            var pathComponents = path.Split(PathSeparators, StringSplitOptions.RemoveEmptyEntries);
+
+            var firstUniqueComponentIndex = FirstUniqueComponentIndex(anchorComponents, pathComponents);
+
+            if (firstUniqueComponentIndex == 0)
+                return path;
+
+            var pathBuilder = new StringBuilder();
+
+            var upDirectoryCount = anchorComponents.Length - firstUniqueComponentIndex;
+            while (upDirectoryCount > 0)
+            {
+                pathBuilder.Append("..");
+                pathBuilder.Append(Path.DirectorySeparatorChar);
+
+                --upDirectoryCount;
+            }
+
+            for (var i = firstUniqueComponentIndex; i < pathComponents.Length; ++i)
+            {
+                pathBuilder.Append(pathComponents[i]);
+
+                if (i < pathComponents.Length - 1)
+                    pathBuilder.Append(Path.DirectorySeparatorChar);
+            }
+
+            return pathBuilder.ToString();
+        }
+
+        private static int FirstUniqueComponentIndex(string[] anchorComponents, string[] pathComponents)
+        {
+            var index = 0;
+            foreach (var s in anchorComponents)
+            {
+                if (index >= pathComponents.Length)
+                    return 0;
+
+                if (s != pathComponents[index])
+                    return index;
+
+                ++index;
+            }
+
+            return 0;
+        }
+    }
+}

--- a/src/i18n.Domain/Helpers/StringExtensions.cs
+++ b/src/i18n.Domain/Helpers/StringExtensions.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using i18n.Domain.Helpers;
 
 namespace i18n.Helpers
 {
@@ -14,19 +15,6 @@ namespace i18n.Helpers
             this string str)
         {
             return !string.IsNullOrEmpty(str);
-        }
-
-        /// <summary>
-        /// Returns the line number (1-based) of the identified character in the string.
-        /// </summary>
-        public static int LineFromPos(this string S, int Pos)
-        {
-            int Res = 1;
-            for (int i = 0; i < Pos; i++) {
-                if (S[i] == '\n') {
-                    Res++; }
-            }
-            return Res;
         }
     }
 }

--- a/src/i18n.Domain/i18n.Domain.csproj
+++ b/src/i18n.Domain/i18n.Domain.csproj
@@ -65,6 +65,7 @@
     <Compile Include="Concrete\WebConfigSettingService.cs" />
     <Compile Include="Entities\Language.cs" />
     <Compile Include="Concrete\POTranslationRepository.cs" />
+    <Compile Include="Entities\ReferenceContext.cs" />
     <Compile Include="Entities\TemplateItem.cs" />
     <Compile Include="Entities\TranslationItem.cs" />
     <Compile Include="Entities\Translation.cs" />
@@ -76,6 +77,7 @@
     <Compile Include="Helpers\HashHelper.cs" />
     <Compile Include="Helpers\LockFreeProperty.cs" />
     <Compile Include="Helpers\NuggetParser.cs" />
+    <Compile Include="Helpers\PathNormalizer.cs" />
     <Compile Include="Helpers\StringExtensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/src/i18n.PostBuild/Program.cs
+++ b/src/i18n.PostBuild/Program.cs
@@ -1,53 +1,122 @@
 ﻿using System;
-using System.Collections;
-using System.Collections.Generic;
 using System.IO;
 using i18n.Domain.Concrete;
 using i18n.Domain.Entities;
+using i18n.Domain.Helpers;
 
 namespace i18n.PostBuild
 {
-    class Program
+    public class Program
     {
-        static void Main(string[] args)
+        public bool ShowHelp { get; set; }
+        public bool ShowSourceContext { get; set; }
+        public string ConfigPath { get; set; }
+
+        public static void Main(string[] args)
         {
-			//TestCode
-	        //args = new string[] {@"C:\viducate2\Viducate\Viducate.WebUI\Web.config"};
+            Environment.ExitCode = 1;
 
-			string configPath;
-			if (args.Length == 0)
-			{
-				System.Console.WriteLine("You have to specify path to web.config.");
-				return;
-			}
+            try
+            {
+                var program = new Program();
+                program.ParseArguments(args);
 
-	        try
-	        {
-		        configPath = args[0];
-				using (FileStream fs = File.Open(configPath, FileMode.Open))
-		        {
-			        
-		        }
-	        }
-	        catch (Exception)
-	        {
-				System.Console.WriteLine("Failed to open config file at path.");
-				return;
-	        }
+                if (program.ShowHelp)
+                {
+                    ShowUsage();
+                }
+                else
+                {
+                    program.Run();
+                }
+
+                Environment.ExitCode = 0;
+            }
+            catch (Exception exception)
+            {
+                Console.WriteLine("ERROR: {0}", exception.Message);
+            }
+        }
+
+        private void ParseArguments(string[] args)
+        {
+            foreach (var arg in args)
+            {
+                if (arg.StartsWith("/") || arg.StartsWith("-"))
+                {
+                    var option = arg.Substring(1);
+
+                    switch (option.ToLowerInvariant())
+                    {
+                        case "help":
+                            ShowHelp = true;
+                            break;
+
+                        case "source":
+                            ShowSourceContext = true;
+                            break;
+
+                        default:
+                            throw new Exception("Unknown option: " + arg);
+                    }
+
+                }
+                else if (string.IsNullOrWhiteSpace(ConfigPath))
+                {
+                    ConfigPath = arg;
+                }
+                else
+                {
+                    throw new Exception("Can only specify one configPath");
+                }
+            }
+
+            ShowHelp = ShowHelp || string.IsNullOrWhiteSpace(ConfigPath);
+        }
+
+        private static void ShowUsage()
+        {
+            Console.WriteLine("usage: i18n.PostBuild [options] configPath");
+            Console.WriteLine();
+            Console.WriteLine("where: configPath - path to web.config file");
+            Console.WriteLine("       /help      - show this message");
+            Console.WriteLine("       /source    - append source context to references");
+            Console.WriteLine();
+        }
+
+        private void Run()
+        {
+            ThrowIfConfigFileNotFound();
+
+            ReferenceContext.ShowSourceContext = ShowSourceContext;
 
 			//todo: this assumes PO files, if not using po files then other solution needed.
-			i18nSettings settings = new i18nSettings(new WebConfigSettingService(configPath));
-			POTranslationRepository rep = new POTranslationRepository(settings);
+			var settings = new i18nSettings(new WebConfigSettingService(ConfigPath));
+			var repository = new POTranslationRepository(settings);
 
-			FileNuggetFinder nugget = new FileNuggetFinder(settings);
-	        var items = nugget.ParseAll();
-	        rep.SaveTemplate(items);
+			var nuggetFinder = new FileNuggetFinder(settings);
+	        var items = nuggetFinder.ParseAll();
+	        repository.SaveTemplate(items);
 
-			TranslationMerger ts = new TranslationMerger(rep);
-			ts.MergeAllTranslation(items);
-			
+			var merger = new TranslationMerger(repository);
+			merger.MergeAllTranslation(items);
 
             Console.WriteLine("i18n.PostBuild completed successfully.");
+        }
+
+        private void ThrowIfConfigFileNotFound()
+        {
+            try
+            {
+                using (File.Open(ConfigPath, FileMode.Open, FileAccess.Read, FileShare.Read))
+                {
+                }
+            }
+            catch (Exception)
+            {
+                Console.WriteLine("Failed to open config file: {0}", ConfigPath);
+                throw;
+            }
         }
     }
 }


### PR DESCRIPTION
Added optional support for showing the source code context next to the source file path and line number.
This helps provide a bit more context for translators who don't have access to the source code.

To enable the feature, add the `/source` or `-source` option to i18n.PostBuild.exe command line.

We have private git repos which we do not share with our translators, but often some terse extracted nuggets can be clarified simply by looking at the original source line. So I added an option that includes the actual source after the source filename & line number.

When the option is enabled, it would turn an ambiguous message definition of `%0 Parameter` like this:
```
#: Views\StatisticDefinition\Form.cshtml:118
msgid "%0 Parameter"
msgstr ""
```

into something a bit more clear like this:
```
#: Views\StatisticDefinition\Form.cshtml:118 [[[Licence Details]]]: @ViewBag.PoolSize - [[[Active]]] - @Model.Type - [[[%0 Parameter|||@Model.ParameterName]]] - [[[Statistic Definitions]]]
msgid "%0 Parameter"
msgstr ""
```

Context like the above is often enough for a tech-savvy translator, (who knows our product domain and knows our software has a view which shows the parameter name of various statistics) to recognize the English text in context, and reason on their own that `%0 Parameter` is a substitution expression for various environmental monitoring parameters like "Accumulated Rain Fall Parameter", and a 'parameter' in the general computer-science context.

It probably isn't safe to always the source context after the reference path and line number. There are plenty of "PO editor" implementations out there, and they might not expect it. It certainly works for the two I've tried (Poedit and Sisulizer), but who knows what else might fall over.

Changes:

1) Added a `PathNormalizer` class to eliminate hard-coded paths showing up in the generated `messages.po` files

Consider this project folder structure:
```
src\
  ProjectA\
    Foo.cs:     return "[[[Foo]]]";
  ProjectB\
    Bar.cs:     return "[[[Bar]]]";
    web.config: <add key="i18n.DirectoriesToScan" value=".;..\ProjectA" />
```

Without path normalization, the following file would be generated:
```
# Bar.cs:88
msgid "Bar"
msgstr ""

# C:\Users\Fred.Derf\Documents\MyLittlePonyFanFiction\git\SuperSecretRepoName\ProjectA\Foo.cs:55
msgid "Foo"
msgstr ""
```

That full path is not really needed, and just adds to the noise in the generated file.

With path normalization, the generated file contains relative path references to ProjectA:
```
# Bar.cs:88
msgid "Bar"
msgstr ""

# ..\ProjectA\Foo.cs:55
msgid "Foo"
msgstr ""
```

The anchor path for normalization is the config file (web.config in this example).

If the path being normalized shares any common root with the anchor path (ie. they exist on the same drive), then a relative path will result. If the path has nothing in common with the anchor path, then the full absolute path is returned. There's nothing to normalize in that case.

2) Added a `ReferenceContext` class to replace the separate `referencePath` string and `lineNumber` integer in the nugget extractor code.

The `ReferenceContext` class also contains a `Context` property from where the nugget was extracted. If the global `ShowSourceContext` flag is true, then this context will be added to the comment line in the generated file.

3) Cleaned up the outer console program logic

The `i18n.PostBuild.exe` tool will now exit with a zero exit code if successful. If anything goes wrong, it exits with a positive exit code. This helps build scripts detect failures when things go sideways.