### PR TITLE
278 configurable headercheck

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,9 @@ code shows the most common options:
 
 			// Change the types of async postback blocks that are localized
 			//i18n.LocalizedApplication.Current.AsyncPostbackTypesToTranslate = "updatePanel,scriptStartupBlock,pageTitle";
+
+            // Change which languages are parsed from the request, like skipping  the "Accept-Language"-header value. The default setting is:
+            //i18n.HttpContextExtensions.GetRequestUserLanguagesImplementation = (context) => LanguageItem.ParseHttpLanguageHeader(context.Request.Headers["Accept-Language"]);
         }
     }
 ```

--- a/src/i18n/Helpers/HttpContextExtensions.cs
+++ b/src/i18n/Helpers/HttpContextExtensions.cs
@@ -194,20 +194,40 @@ namespace i18n
             if (UserLanguages == null)
             {
                 // Construct UserLanguages list and cache it for the rest of the request.
-	            context.Items["i18n.UserLanguages"]
-		            = UserLanguages = GetRequestUserLanguagesImplementation(context);
-	            // NB: originally we passed LocalizedApplication.Current.DefaultLanguageTag
-	            // here as the second parameter i.e. to specify the PAL. However, this was
-	            // found to be incorrect when operating i18n with EarlyUrlLocalization disabled,
-	            // as SetPrincipalAppLanguageForRequest was not being called, that normally
-	            // overwriting the PAL set erroneously here.
+	            context.Items["i18n.UserLanguages"] = UserLanguages = GetRequestUserLanguagesImplementation(context);
             }
             return UserLanguages;
         }
 
-	    public delegate LanguageItem[] GetRequestUserLanguagesProc(System.Web.HttpContextBase context);
+		/// <summary>
+		/// Describes a procedure for determining the user languages for the current request.
+		/// </summary>
+		/// <param name="context">
+		/// Describes the current request. May be null if called outside of any request.
+		/// </param>
+		/// <returns>The language items which are determined for the current current request.</returns>
+		/// <remarks>
+		/// <see cref="HttpContextExtensions.GetRequestUserLanguagesImplementation"/>
+		/// </remarks>
+		public delegate LanguageItem[] GetRequestUserLanguagesProc(System.Web.HttpContextBase context);
 
-	    public static GetRequestUserLanguagesProc GetRequestUserLanguagesImplementation { get; set; } = (context) => LanguageItem.ParseHttpLanguageHeader(context.Request.Headers["Accept-Language"]);
+		/// <summary>
+		/// Registers the procedure used by instances of this class for determining the 
+		/// available user languages for the current request.
+		/// </summary>
+		/// <remarks>
+		/// The default implementation will check the `Accept-Language` header attribute 
+		/// for the available languages in the current request.
+		/// </remarks>
+		public static GetRequestUserLanguagesProc GetRequestUserLanguagesImplementation { get; set; } = (context) =>
+		{
+			return LanguageItem.ParseHttpLanguageHeader(context.Request.Headers["Accept-Language"]);
+			// NB: originally we passed LocalizedApplication.Current.DefaultLanguageTag
+			// here as the second parameter i.e. to specify the PAL. However, this was
+			// found to be incorrect when operating i18n with EarlyUrlLocalization disabled,
+			// as SetPrincipalAppLanguageForRequest was not being called, that normally
+			// overwriting the PAL set erroneously here.
+		};
 
 		/// <summary>
 		/// Add a Content-Language HTTP header to the response, based on any languages

--- a/src/i18n/Helpers/HttpContextExtensions.cs
+++ b/src/i18n/Helpers/HttpContextExtensions.cs
@@ -194,29 +194,31 @@ namespace i18n
             if (UserLanguages == null)
             {
                 // Construct UserLanguages list and cache it for the rest of the request.
-                context.Items["i18n.UserLanguages"] 
-                    = UserLanguages 
-                    = LanguageItem.ParseHttpLanguageHeader(
-                        context.Request.Headers["Accept-Language"]);
-                            // NB: originally we passed LocalizedApplication.Current.DefaultLanguageTag
-                            // here as the second parameter i.e. to specify the PAL. However, this was
-                            // found to be incorrect when operating i18n with EarlyUrlLocalization disabled,
-                            // as SetPrincipalAppLanguageForRequest was not being called, that normally
-                            // overwriting the PAL set erroneously here.
+	            context.Items["i18n.UserLanguages"]
+		            = UserLanguages = GetRequestUserLanguagesImplementation(context);
+	            // NB: originally we passed LocalizedApplication.Current.DefaultLanguageTag
+	            // here as the second parameter i.e. to specify the PAL. However, this was
+	            // found to be incorrect when operating i18n with EarlyUrlLocalization disabled,
+	            // as SetPrincipalAppLanguageForRequest was not being called, that normally
+	            // overwriting the PAL set erroneously here.
             }
             return UserLanguages;
         }
 
-        /// <summary>
-        /// Add a Content-Language HTTP header to the response, based on any languages
-        /// that have provided resources during the request.
-        /// </summary>
-        /// <param name="context">Context of the current request.</param>
-        /// <returns>
-        /// true if header added; false if no languages provided content during the request and
-        /// so no header was added.
-        /// </returns>
-        public static bool SetContentLanguageHeader(this System.Web.HttpContext context)
+	    public delegate LanguageItem[] GetRequestUserLanguagesProc(System.Web.HttpContextBase context);
+
+	    public static GetRequestUserLanguagesProc GetRequestUserLanguagesImplementation { get; set; } = (context) => LanguageItem.ParseHttpLanguageHeader(context.Request.Headers["Accept-Language"]);
+
+		/// <summary>
+		/// Add a Content-Language HTTP header to the response, based on any languages
+		/// that have provided resources during the request.
+		/// </summary>
+		/// <param name="context">Context of the current request.</param>
+		/// <returns>
+		/// true if header added; false if no languages provided content during the request and
+		/// so no header was added.
+		/// </returns>
+		public static bool SetContentLanguageHeader(this System.Web.HttpContext context)
         {
             return context.GetHttpContextBase().SetContentLanguageHeader();
         }

--- a/src/i18n/Helpers/HttpContextExtensions.cs
+++ b/src/i18n/Helpers/HttpContextExtensions.cs
@@ -10,6 +10,19 @@ namespace i18n
 {
     public static class HttpContextExtensions
     {
+        static HttpContextExtensions()
+        {
+            GetRequestUserLanguagesImplementation = (context) =>
+            {
+	            return LanguageItem.ParseHttpLanguageHeader(context.Request.Headers["Accept-Language"]);
+	            // NB: originally we passed LocalizedApplication.Current.DefaultLanguageTag
+	            // here as the second parameter i.e. to specify the PAL. However, this was
+	            // found to be incorrect when operating i18n with EarlyUrlLocalization disabled,
+	            // as SetPrincipalAppLanguageForRequest was not being called, that normally
+	            // overwriting the PAL set erroneously here.
+            };
+        }
+
         /// <summary>
         /// Returns an System.Web.HttpContextBase for the current System.Web.HttpContext.
         /// Facilitates efficient consolidation of methods that require support for both 
@@ -216,18 +229,10 @@ namespace i18n
 		/// available user languages for the current request.
 		/// </summary>
 		/// <remarks>
-		/// The default implementation will check the `Accept-Language` header attribute 
+		/// The default implementation is set in the static constructor and will check the `Accept-Language` header attribute 
 		/// for the available languages in the current request.
 		/// </remarks>
-		public static GetRequestUserLanguagesProc GetRequestUserLanguagesImplementation { get; set; } = (context) =>
-		{
-			return LanguageItem.ParseHttpLanguageHeader(context.Request.Headers["Accept-Language"]);
-			// NB: originally we passed LocalizedApplication.Current.DefaultLanguageTag
-			// here as the second parameter i.e. to specify the PAL. However, this was
-			// found to be incorrect when operating i18n with EarlyUrlLocalization disabled,
-			// as SetPrincipalAppLanguageForRequest was not being called, that normally
-			// overwriting the PAL set erroneously here.
-		};
+		public static GetRequestUserLanguagesProc GetRequestUserLanguagesImplementation { get; set; }
 
 		/// <summary>
 		/// Add a Content-Language HTTP header to the response, based on any languages


### PR DESCRIPTION
Created delegate to let the developers decide what functionality should be implemented when parsing the user request languages. Necessary if you want to skip the "Accept-Language"-header.

Issue can be found over here: https://github.com/turquoiseowl/i18n/issues/278