### PR TITLE
Add option to generate a pot file per file scanned by the PostBuild g…

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,12 +60,14 @@ of your application's source files:
   </appSettings>
 ```
 
-The following one is optional. It allows you to generate lighter pot/po files by deleting 
-references to your translation tokens (nuggets) :
+The following configuration options are optional. ```i18n.DisableReferences``` allows you to generate lighter pot/po files by deleting 
+references to your translation tokens (nuggets) and ```i18n.GenerateTemplatePerFile``` generates a pot file per file scanned and merges
+all po files into messages.po:
 
 ```xml
   <appSettings>
     <add key="i18n.DisableReferences" value="true" />
+    <add key="i18n.GenerateTemplatePerFile" value="true" />
   </appSettings>
 ```
 

--- a/src/i18n.Domain/Abstract/ITranslationRepository.cs
+++ b/src/i18n.Domain/Abstract/ITranslationRepository.cs
@@ -21,8 +21,9 @@ namespace i18n.Domain.Abstract
         /// Retrieves a translation with all items (both with translation set and not)
         /// </summary>
         /// <param name="langtag">The language tag to get the translation for. For instance "sv-SE"</param>
+        /// <param name="fileNames">A list of file names generated.</param>
         /// <returns>A Translation object with the Language->LanguageShortTag set and all the translation items returned in a Dictionary</returns>
-        Translation GetTranslation(string langtag);
+        Translation GetTranslation(string langtag, List<string> fileNames = null);
 
         /// <summary>
         /// Gets all available languages. There is a setting for available languages that can be used by the implementation. But the implementation can if prefered use other method.

--- a/src/i18n.Domain/Concrete/FileNuggetFinder.cs
+++ b/src/i18n.Domain/Concrete/FileNuggetFinder.cs
@@ -113,8 +113,13 @@ namespace i18n.Domain.Concrete
                     var referenceContext = _settings.DisableReferences
                         ? ReferenceContext.Create("Disabled references", i_entity, 0)
                         : ReferenceContext.Create(referencePath, i_entity, pos);
+                    var fileName = Path.GetFileNameWithoutExtension(filePath);
+                    // If we have a file like "myfile.aspx.vb" then the fileName will be "myfile.aspx" resulting in split
+                    // .pot files. So remove all extensions, so that we just have the actual name to deal with.
+                    fileName = fileName.IndexOf('.') > -1 ? fileName.Split('.')[0] : fileName;
 
                     AddNewTemplateItem(
+                        fileName,
                         referenceContext,
                         nugget, 
                         templateItems);
@@ -125,6 +130,7 @@ namespace i18n.Domain.Concrete
         }
 
         private void AddNewTemplateItem(
+            string fileName,
             ReferenceContext referenceContext,
             Nugget nugget, 
             ConcurrentDictionary<string, TemplateItem> templateItems)
@@ -141,6 +147,7 @@ namespace i18n.Domain.Concrete
                     TemplateItem item = new TemplateItem();
                     item.MsgKey = key;
                     item.MsgId = msgid;
+                    item.FileName = fileName;
 
                     item.References = new List<ReferenceContext> {referenceContext};
 

--- a/src/i18n.Domain/Concrete/TranslationMerger.cs
+++ b/src/i18n.Domain/Concrete/TranslationMerger.cs
@@ -44,7 +44,8 @@ namespace i18n.Domain.Concrete
         {
             foreach (var language in _repository.GetAvailableLanguages())
             {
-                MergeTranslation(items, _repository.GetTranslation(language.LanguageShortTag));
+                var filesNames = items.GroupBy(x => x.Value.FileName).Select(x => x.Key).ToList();
+                MergeTranslation(items, _repository.GetTranslation(language.LanguageShortTag, filesNames));
             }
         }
 

--- a/src/i18n.Domain/Concrete/i18nSettings.cs
+++ b/src/i18n.Domain/Concrete/i18nSettings.cs
@@ -575,5 +575,35 @@ namespace i18n.Domain.Concrete
             }
         }
         #endregion
-}
+
+        #region GenerateTemplatePerFile
+
+        private bool? _cached_generateTemplatePerFile;
+        public virtual bool GenerateTemplatePerFile
+        {
+            get
+            {
+                // NB: this is not particularly thread-safe, but not seen as dangerous
+                // if done concurrently as modification is one-way.
+                if (_cached_generateTemplatePerFile != null)
+                {
+                    return _cached_generateTemplatePerFile.Value;
+                }
+
+                string prefixedString = GetPrefixedString("GenerateTemplatePerFile");
+                string setting = _settingService.GetSetting(prefixedString);
+                bool result = !string.IsNullOrEmpty(setting) && setting == "true";
+                _cached_generateTemplatePerFile = result;
+                return _cached_generateTemplatePerFile.Value;
+            }
+            set
+            {
+                string prefixedString = GetPrefixedString("GenerateTemplatePerFile");
+                _settingService.SetSetting(prefixedString, value ? "true" : "false");
+                _cached_generateTemplatePerFile = value;
+            }
+        }
+
+        #endregion
+    }
 }

--- a/src/i18n.Domain/Entities/TemplateItem.cs
+++ b/src/i18n.Domain/Entities/TemplateItem.cs
@@ -17,6 +17,7 @@ namespace i18n.Domain.Entities
         public string MsgId;
         public IEnumerable<ReferenceContext> References { get; set; }
         public IEnumerable<string> Comments { get; set; }
+        public string FileName { get; set; }
 
         public override string ToString()
         {


### PR DESCRIPTION
…enerator

When using the current solution for a very large project the size of the pot/po files can become quite hard to manage and collaboration can be a bit awkward, so a solution to this issue was to have the ability for the PostBuild generator to build a template file per file scanned and then scan for any po files created for those templates and merge them into the main messages.po file.

Added the ability to do this in the form of a config option, so it can be enabled or disabled easily.