### PR TITLE
Optimised i18n IO operations when spliting messages.pot into separate…

### DIFF
--- a/src/i18n.Domain/Abstract/ITranslationRepository.cs
+++ b/src/i18n.Domain/Abstract/ITranslationRepository.cs
@@ -22,8 +22,9 @@ namespace i18n.Domain.Abstract
         /// </summary>
         /// <param name="langtag">The language tag to get the translation for. For instance "sv-SE"</param>
         /// <param name="fileNames">A list of file names generated.</param>
+        /// <param name="loadingCache">Flag determining whether the call came from the generator or the localizing module.</param>
         /// <returns>A Translation object with the Language->LanguageShortTag set and all the translation items returned in a Dictionary</returns>
-        Translation GetTranslation(string langtag, List<string> fileNames = null);
+        Translation GetTranslation(string langtag, List<string> fileNames = null, bool loadingCache = true);
 
         /// <summary>
         /// Gets all available languages. There is a setting for available languages that can be used by the implementation. But the implementation can if prefered use other method.

--- a/src/i18n.Domain/Concrete/POTranslationRepository.cs
+++ b/src/i18n.Domain/Concrete/POTranslationRepository.cs
@@ -25,9 +25,9 @@ namespace i18n.Domain.Concrete
 
         #region load and getters
 
-        public Translation GetTranslation(string langtag, List<string> fileNames = null)
+        public Translation GetTranslation(string langtag, List<string> fileNames = null, bool loadingCache = true)
         {
-            return ParseTranslationFile(langtag, fileNames);
+            return ParseTranslationFile(langtag, fileNames, loadingCache);
         }
 
 
@@ -378,7 +378,7 @@ namespace i18n.Domain.Concrete
         /// </summary>
         /// <param name="langtag">The language (tag) you wish to load into Translation object</param>
         /// <returns>A complete translation object with all all translations and language values set.</returns>
-        private Translation ParseTranslationFile(string langtag, List<string> fileNames)
+        private Translation ParseTranslationFile(string langtag, List<string> fileNames, bool loadingCache)
         {
             //todo: consider that lines we don't understand like headers from poedit and #| should be preserved and outputted again.
 
@@ -390,7 +390,7 @@ namespace i18n.Domain.Concrete
 
             List<string> paths = new List<string>();
 
-            if (!_settings.GenerateTemplatePerFile)
+            if (!_settings.GenerateTemplatePerFile || loadingCache)
                 paths.Add(GetPathForLanguage(langtag));
 
             foreach (var file in _settings.LocaleOtherFiles)
@@ -398,7 +398,7 @@ namespace i18n.Domain.Concrete
                 paths.Add(GetPathForLanguage(langtag, file));
             }
 
-            if (_settings.GenerateTemplatePerFile)
+            if (_settings.GenerateTemplatePerFile && !loadingCache)
             {
                 if (fileNames != null && fileNames.Count > 0)
                 {

--- a/src/i18n.Domain/Concrete/TranslationMerger.cs
+++ b/src/i18n.Domain/Concrete/TranslationMerger.cs
@@ -45,7 +45,7 @@ namespace i18n.Domain.Concrete
             foreach (var language in _repository.GetAvailableLanguages())
             {
                 var filesNames = items.GroupBy(x => x.Value.FileName).Select(x => x.Key).ToList();
-                MergeTranslation(items, _repository.GetTranslation(language.LanguageShortTag, filesNames));
+                MergeTranslation(items, _repository.GetTranslation(language.LanguageShortTag, filesNames, false));
             }
         }
 


### PR DESCRIPTION
… files

From #314, I have added some IO optimization so that when files are split, they are not separately cached and instead the merged messages.po file is the only one that is cached.