### PR TITLE
Resolve issue where generator was loading the messages.po file when G…

### DIFF
--- a/src/i18n.Domain/Concrete/POTranslationRepository.cs
+++ b/src/i18n.Domain/Concrete/POTranslationRepository.cs
@@ -393,9 +393,12 @@ namespace i18n.Domain.Concrete
             if (!_settings.GenerateTemplatePerFile || loadingCache)
                 paths.Add(GetPathForLanguage(langtag));
 
-            foreach (var file in _settings.LocaleOtherFiles)
+            if (loadingCache)
             {
-                paths.Add(GetPathForLanguage(langtag, file));
+                foreach (var file in _settings.LocaleOtherFiles)
+                {
+                    paths.Add(GetPathForLanguage(langtag, file));
+                }
             }
 
             if (_settings.GenerateTemplatePerFile && !loadingCache)

--- a/src/i18n.PostBuild/Program.cs
+++ b/src/i18n.PostBuild/Program.cs
@@ -93,7 +93,6 @@ namespace i18n.PostBuild
 
             //todo: this assumes PO files, if not using po files then other solution needed.
             var settings = new i18nSettings(new WebConfigSettingService(ConfigPath));
-            settings.LocaleOtherFiles = Enumerable.Empty<string>();
             var repository = new POTranslationRepository(settings);
 
             var nuggetFinder = new FileNuggetFinder(settings);


### PR DESCRIPTION
…enerateTemplatePerFile option is set to true.

When the GenerateTemplatePerFile option is set to true we merge every po file into the main messages.po file. This change makes sure we do not load the messages.po file during generation if this option is true.