### PR TITLE
Extensionattributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,6 +386,29 @@ Please note that conditionals work like C# switch - you can specify the translat
 
 This can be useful both for inflection of genders and numbers (singular/plural).
 
+#### Extension Attributes
+
+Conditionals allow you to create conditional translations depending on the argument itself, but sometimes the decision must not be made on something that you know in advance but rather on some language-specific attribute.
+For example, "map" in portuguese is masculine gender but in french it's feminine gender.
+
+Portuguese:
+```
+[[[The %0 is being exported.]]] -> "%0_GENDER{M:O %0 está sendo exportado.|A %0 está sendo exportada.}" 
+[[[map]]] -> "mapa"
+[[[map_GENDER]]] -> "M"
+[[[The %0 is being exported.|||(((map)))]]]  -> "O mapa está sendo exportado" (masculine)
+```
+
+French:
+```
+[[[The %0 is being exported.]]] -> "%0_GENDER{M:Le %0 a été exporté.|F:La %0 a été exporté.}"
+[[[map]]] -> "carte"
+[[[map_GENDER]]] -> "F"
+[[[The %0 is being exported.|||(((map)))]]]  -> "Le carte a été exporté" (feminine)
+```
+
+You can create attributes for gender, number (singular/plural), etc. Attributes may be only part of the the translation language.
+
 
 #### Parameters inside Parameters
 

--- a/README.md
+++ b/README.md
@@ -370,6 +370,20 @@ message spread over
 three lines]]]
 ```
 
+#### Parameters inside Parameters
+
+This helps you to reuse some parametrized translations inside other parametrized translations.
+For example:
+
+```
+[[[Product]]] -> "Produto"
+[[[%0 Status]]] -> "Status do %0"
+[[[Please select a %0]]] -> "Por favor escolha o %0"
+
+[[[Please select a %0|||(((%0 Status|||(((Product))))))]]] -> "Por favor escolha o Status do Produto"
+```
+
+
 ### Static File Compression and i18n
 The i18n module localizes nuggets in the HTTP response by modifying the response stream using a response filter 
 (see the .NET Framework documentation for more info about the HttpResponse.Filter property).

--- a/README.md
+++ b/README.md
@@ -370,6 +370,23 @@ message spread over
 three lines]]]
 ```
 
+#### Conditionals
+
+With **conditionals** you can use a single nugget tag and have different translations according to the value of parameters.
+
+```
+[[[%0_PRODUCTS_ADDED_TO_ORDER]]] -> 
+"%0{0:No products were added|1:1 product was added|%0 products were added} to your order" 
+
+[[[DEAR_SIR_OR_MADAM|||@ViewBag.Gender]]] -> 
+"Dear %0{M:Sir|F:Madam|user}"
+```
+
+Please note that conditionals work like C# switch - you can specify the translation for each expected value ("No products" for "0", "1 product" for "1") and specify a translation for all other cases ("%0 products").
+
+This can be useful both for inflection of genders and numbers (singular/plural).
+
+
 #### Parameters inside Parameters
 
 This helps you to reuse some parametrized translations inside other parametrized translations.

--- a/src/i18n.Domain.Tests/NuggetParserTests.cs
+++ b/src/i18n.Domain.Tests/NuggetParserTests.cs
@@ -13,7 +13,7 @@ namespace i18n.Domain.Tests
         private void ParseAndComp(string nuggetString, Nugget rhs, bool equal = true)
         {
            // Arrange.
-            NuggetTokens nuggetTokens = new NuggetTokens("[[[", "]]]", "|||", "///");
+            NuggetTokens nuggetTokens = new NuggetTokens("[[[", "]]]", "|||", "///", "(((", ")))");
             NuggetParser nuggetParser = new NuggetParser(nuggetTokens, NuggetParser.Context.SourceProcessing);
            // Act.
             Nugget nugget = nuggetParser.BreakdownNugget(nuggetString);
@@ -74,7 +74,7 @@ namespace i18n.Domain.Tests
         public void NuggetParser_CanParseEntity01()
         {
            // Arrange.
-            NuggetTokens nuggetTokens = new NuggetTokens("[[[", "]]]", "|||", "///");
+            NuggetTokens nuggetTokens = new NuggetTokens("[[[", "]]]", "|||", "///", "(((", ")))");
             NuggetParser nuggetParser = new NuggetParser(nuggetTokens, NuggetParser.Context.SourceProcessing);
             string entity = "<p>[[[hello]]]</p><p>[[[there]]]</p>";
            // Act.
@@ -94,7 +94,7 @@ namespace i18n.Domain.Tests
         public void NuggetParser_CanParseEntity02()
         {
            // Arrange.
-            NuggetTokens nuggetTokens = new NuggetTokens("[[[", "]]]", "|||", "///");
+            NuggetTokens nuggetTokens = new NuggetTokens("[[[", "]]]", "|||", "///", "(((", ")))");
             NuggetParser nuggetParser = new NuggetParser(nuggetTokens, NuggetParser.Context.SourceProcessing);
             string entity = "<p>[[[hello|||{0}]]]</p><p>[[[there]]]</p>";
            // Act.
@@ -114,7 +114,7 @@ namespace i18n.Domain.Tests
         public void NuggetParser_CanParseEntity03()
         {
            // Arrange.
-            NuggetTokens nuggetTokens = new NuggetTokens("[[[", "]]]", "|||", "///");
+            NuggetTokens nuggetTokens = new NuggetTokens("[[[", "]]]", "|||", "///", "(((", ")))");
             NuggetParser nuggetParser = new NuggetParser(nuggetTokens, NuggetParser.Context.SourceProcessing);
             string entity = "<p>[[[hello|||{0}]]]</p><p>[[[there|||{0}|||{1}///comment comment comment]]]</p>";
            // Act.
@@ -134,7 +134,7 @@ namespace i18n.Domain.Tests
         public void NuggetParser_CanParseEntity_CustomNuggetTokens01()
         {
            // Arrange.
-            NuggetTokens nuggetTokens = new NuggetTokens("[[[[", "]]]]]", "||", "//");
+            NuggetTokens nuggetTokens = new NuggetTokens("[[[[", "]]]]]", "||", "//", "(((", ")))");
             NuggetParser nuggetParser = new NuggetParser(nuggetTokens, NuggetParser.Context.SourceProcessing);
             string entity = "<p>[[[[hello||{0}]]]]]</p><p>[[[[there||{0}||{1}//comment comment comment]]]]]</p>";
            // Act.
@@ -145,7 +145,7 @@ namespace i18n.Domain.Tests
         public void NuggetParser_CanParseEntity_CustomNuggetTokens02()
         {
            // Arrange.
-            NuggetTokens nuggetTokens = new NuggetTokens("[[[:", ":]]]", "|||", "///");
+            NuggetTokens nuggetTokens = new NuggetTokens("[[[:", ":]]]", "|||", "///", "(((", ")))");
             NuggetParser nuggetParser = new NuggetParser(nuggetTokens, NuggetParser.Context.SourceProcessing);
             string entity = "<p>[[[:hello|||{0}:]]]</p><p>[[[:there|||{0}|||{1}///comment comment comment:]]]</p>";
            // Act.
@@ -156,7 +156,7 @@ namespace i18n.Domain.Tests
         public void NuggetParser_CanParseEntity_CustomNuggetTokens03()
         {
            // Arrange.
-            NuggetTokens nuggetTokens = new NuggetTokens("```", "'''", "###", "@@@");
+            NuggetTokens nuggetTokens = new NuggetTokens("```", "'''", "###", "@@@", "[[[", "]]]");
             NuggetParser nuggetParser = new NuggetParser(nuggetTokens, NuggetParser.Context.SourceProcessing);
             string entity = "<p>```hello###{0}'''</p><p>```there###{0}###{1}@@@comment comment comment'''</p>";
            // Act.
@@ -167,7 +167,7 @@ namespace i18n.Domain.Tests
         public void NuggetParser_CanParseEntity_MultiLineNugget01()
         {
            // Arrange.
-            NuggetTokens nuggetTokens = new NuggetTokens("[[[", "]]]", "|||", "///");
+            NuggetTokens nuggetTokens = new NuggetTokens("[[[", "]]]", "|||", "///", "(((", ")))");
             NuggetParser nuggetParser = new NuggetParser(nuggetTokens, NuggetParser.Context.SourceProcessing);
             string entity = "<p>[[[hello\r\n%0|||{0}]]]</p><p>[[[there]]]</p>";
            // Act.
@@ -194,7 +194,7 @@ namespace i18n.Domain.Tests
         [TestMethod]
         [Description("Issue #110: Parsing a nugget with empty parameter in Response should not leave delimiters intact.")]
         public void NuggetParser_ResponseMode_CanParseEntity_EmptyParam() {
-            var nuggetTokens = new NuggetTokens("[[[", "]]]", "|||", "///");
+            var nuggetTokens = new NuggetTokens("[[[", "]]]", "|||", "///", "(((", ")))");
             NuggetParser nuggetParser = new NuggetParser(nuggetTokens, NuggetParser.Context.ResponseProcessing);
             var input = "[[[Title: %0|||]]]";
             var result = nuggetParser.ParseString(input, (nuggetString, pos, nugget, i_entity) => {
@@ -210,7 +210,7 @@ namespace i18n.Domain.Tests
         [TestMethod]
         [Description("Issue #110: Parsing a nugget with empty parameter in Source should leave delimiters intact.")]
         public void NuggetParser_SourceMode_CanParseEntity_EmptyParam() {
-            var nuggetTokens = new NuggetTokens("[[[", "]]]", "|||", "///");
+            var nuggetTokens = new NuggetTokens("[[[", "]]]", "|||", "///", "(((", ")))");
             NuggetParser nuggetParser = new NuggetParser(nuggetTokens, NuggetParser.Context.SourceProcessing);
             var input = "[[[Title: %0|||]]]";
             var result = nuggetParser.ParseString(input, (nuggetString, pos, nugget, i_entity) => {
@@ -224,7 +224,7 @@ namespace i18n.Domain.Tests
         [TestMethod]
         [Description("Issue #165: Parsing a nugget with empty parameter in Response should not give format exception.")]
         public void NuggetParser_ResponseMode_CanParseEntity_TwoParams_FirstEmpty_SecondNonEmpty() {
-            var nuggetTokens = new NuggetTokens("[[[", "]]]", "|||", "///");
+            var nuggetTokens = new NuggetTokens("[[[", "]]]", "|||", "///", "(((", ")))");
             NuggetParser nuggetParser = new NuggetParser(nuggetTokens, NuggetParser.Context.ResponseProcessing);
             var input = "[[[Title: %0, %1||||||X]]]";
             var result = nuggetParser.ParseString(input, (nuggetString, pos, nugget, i_entity) => {
@@ -238,7 +238,7 @@ namespace i18n.Domain.Tests
         [TestMethod]
         [Description("Issue #165: Parsing a nugget with empty parameter in Response should not give format exception.")]
         public void NuggetParser_ResponseMode_CanParseEntity_TwoParams_FirstNonEmpty_SecondEmpty() {
-            var nuggetTokens = new NuggetTokens("[[[", "]]]", "|||", "///");
+            var nuggetTokens = new NuggetTokens("[[[", "]]]", "|||", "///", "(((", ")))");
             NuggetParser nuggetParser = new NuggetParser(nuggetTokens, NuggetParser.Context.ResponseProcessing);
             var input = "[[[Title: %0, %1|||X|||]]]";
             var result = nuggetParser.ParseString(input, (nuggetString, pos, nugget, i_entity) => {

--- a/src/i18n.Domain/Concrete/FileNuggetFinder.cs
+++ b/src/i18n.Domain/Concrete/FileNuggetFinder.cs
@@ -24,7 +24,9 @@ namespace i18n.Domain.Concrete
                 _settings.NuggetBeginToken,
                 _settings.NuggetEndToken,
                 _settings.NuggetDelimiterToken,
-                _settings.NuggetCommentToken),
+                _settings.NuggetCommentToken,
+                _settings.NuggetParameterBeginToken,
+                _settings.NuggetParameterEndToken),
                 NuggetParser.Context.SourceProcessing);
         }
 

--- a/src/i18n.Domain/Helpers/NuggetParser.cs
+++ b/src/i18n.Domain/Helpers/NuggetParser.cs
@@ -25,22 +25,30 @@ namespace i18n.Helpers
         public string EndToken       { get; private set; }
         public string DelimiterToken { get; private set; }
         public string CommentToken   { get; private set; }
+        public string ParameterBeginToken { get; private set; }
+        public string ParameterEndToken { get; private set; }
 
         public NuggetTokens(
             string beginToken,
             string endToken,
             string delimiterToken,
-            string commentToken)
+            string commentToken,
+            string parameterBeginToken,
+            string parameterEndToken)
         {
             if (!beginToken.IsSet())     { throw new ArgumentNullException("beginToken"); }
             if (!endToken.IsSet())       { throw new ArgumentNullException("endToken"); }
             if (!delimiterToken.IsSet()) { throw new ArgumentNullException("delimiterToken"); }
             if (!commentToken.IsSet())   { throw new ArgumentNullException("commentToken"); }
+            if (!parameterBeginToken.IsSet()) { throw new ArgumentNullException("parameterBeginToken"); }
+            if (!parameterEndToken.IsSet()) { throw new ArgumentNullException("parameterEndToken"); }
 
             BeginToken = beginToken;
             EndToken = endToken;
             DelimiterToken = delimiterToken;
             CommentToken = commentToken;
+            ParameterBeginToken = parameterBeginToken;
+            ParameterEndToken = parameterEndToken;
         }
     }
 
@@ -144,16 +152,38 @@ namespace i18n.Helpers
         {
             m_nuggetTokens = nuggetTokens;
             m_context = context;
-           // Prep the regexes. We escape each token char to ensure it is not misinterpreted.
-           // · Breakdown e.g. "\[\[\[(.+?)(?:\|\|\|(.+?))*(?:\/\/\/(.+?))?\]\]\]"
+            // Prep the regexes. We escape each token char to ensure it is not misinterpreted.
+            // · Breakdown e.g. "\[\[\[(.+?)(?:\|\|\|(.+?))*(?:\/\/\/(.+?))?\]\]\]"
+            // This regex allows parameters inside parameters (recursive parameters)
+            //e.g. [[[This %0 allows %1 to have %2|||regex|||nuggets|||(((recursive %0|||(((parameters///comment3)))///comment2)))///comment1]]]
+            // will become "This regex allows nuggets to have recursive parameters"
             m_regexNuggetBreakdown = new Regex(
-                string.Format(@"{0}(.+?)(?:{1}(.{4}?))*(?:{2}(.+?))?{3}",
-                    EscapeString(m_nuggetTokens.BeginToken), 
-                    EscapeString(m_nuggetTokens.DelimiterToken), 
-                    EscapeString(m_nuggetTokens.CommentToken), 
+                string.Format(@"{0}
+                                    (?<msgid>.+?)                 # as few as possible will make the capture first extract the parameters and comments
+                                    ({1}
+                                        (?<parameters>
+                                            (?>
+                                            {5}  (?<LEVEL>)       # On parameter opening push level
+                                            |
+                                            {6} (?<-LEVEL>)       # On parameter closing pop level
+                                            |
+                                            (?! {5} | {6}  ) .    # Match any char unless the opening and closing strings   
+                                            )*?                   # as few as possible, allowing other parameters to start a new capture occurrence
+                                            (?(LEVEL)(?!))        # If level exists (parameter was not correctly closed) then fail - (balancing groups)
+                                        )
+                                    )*
+                                    (?<msgctxt>{2}(.+?))?
+                                {3}",
+                    EscapeString(m_nuggetTokens.BeginToken),
+                    EscapeString(m_nuggetTokens.DelimiterToken),
+                    EscapeString(m_nuggetTokens.CommentToken),
                     EscapeString(m_nuggetTokens.EndToken),
-                    m_context == Context.SourceProcessing ? "+" : "*"), 
-                RegexOptions.CultureInvariant 
+                    m_context == Context.SourceProcessing ? "+" : "*", // not sure why this was used before, or how to add in this new recursive parameters regex
+                    EscapeString(m_nuggetTokens.ParameterBeginToken),
+                    EscapeString(m_nuggetTokens.ParameterEndToken)
+                    ),
+                    RegexOptions.CultureInvariant
+                    | RegexOptions.IgnorePatternWhitespace
                     | RegexOptions.Singleline);
                         // RegexOptions.Singleline in fact enable multi-line nuggets.
         }
@@ -231,14 +261,13 @@ namespace i18n.Helpers
         /// </summary>
         private Nugget NuggetFromRegexMatch(Match match)
         {
-            if (!match.Success
-                || match.Groups.Count != 4) {
-                return null; }
+            if (!match.Success)
+                return null;
             Nugget n = new Nugget();
            // Extract msgid from 2nd capture group.
-            n.MsgId = match.Groups[1].Value;
+            n.MsgId = match.Groups["msgid"].Value;
            // Extract format items from 3rd capture group.
-            var formatItems = match.Groups[2].Captures;
+            var formatItems = match.Groups["parameters"].Captures;
             if (formatItems.Count != 0) {
                 n.FormatItems = new string[formatItems.Count];
                 int i = 0;
@@ -250,8 +279,8 @@ namespace i18n.Helpers
                 }
             }
            // Extract comment from 4th capture group.
-            if (match.Groups[3].Value.IsSet()) {
-                n.Comment = match.Groups[3].Value; }
+            if (match.Groups["msgctxt"].Value.IsSet()) {
+                n.Comment = match.Groups["msgctxt"].Value; }
            // Success.
             return n;
         }

--- a/src/i18n.Domain/Helpers/NuggetParser.cs
+++ b/src/i18n.Domain/Helpers/NuggetParser.cs
@@ -168,17 +168,17 @@ namespace i18n.Helpers
                                             {6} (?<-LEVEL>)       # On parameter closing pop level
                                             |
                                             (?! {5} | {6}  ) .    # Match any char unless the opening and closing strings   
-                                            )*?                   # as few as possible, allowing other parameters to start a new capture occurrence
+                                            ){4}?                 # as few as possible, allowing other parameters to start a new capture occurrence
                                             (?(LEVEL)(?!))        # If level exists (parameter was not correctly closed) then fail - (balancing groups)
                                         )
                                     )*
-                                    (?<msgctxt>{2}(.+?))?
+                                    ({2}(?<msgctxt>(.+?)))?
                                 {3}",
                     EscapeString(m_nuggetTokens.BeginToken),
                     EscapeString(m_nuggetTokens.DelimiterToken),
                     EscapeString(m_nuggetTokens.CommentToken),
                     EscapeString(m_nuggetTokens.EndToken),
-                    m_context == Context.SourceProcessing ? "+" : "*", // not sure why this was used before, or how to add in this new recursive parameters regex
+                    m_context == Context.SourceProcessing ? "+" : "*", // Issue #110: Parsing a nugget with empty parameter in Source should leave delimiters intact. - see test NuggetParser_SourceMode_CanParseEntity_EmptyParam
                     EscapeString(m_nuggetTokens.ParameterBeginToken),
                     EscapeString(m_nuggetTokens.ParameterEndToken)
                     ),

--- a/src/i18n.Tests/Helpers/TextLocalizer_Mock_Generic.cs
+++ b/src/i18n.Tests/Helpers/TextLocalizer_Mock_Generic.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Text;
+using i18n;
+
+namespace i18n.Tests
+{
+    /// <summary>
+    /// Mock implementation of ITextLocalizer with simplest of logic:
+    /// · Supports single msgid/msgstr pair passed to cstor.
+    /// · GetText checks that the UserLanguage spec. matches "en" and if so
+    ///   and msgid matches that passed to cstor, then returns the msgstr passed to cstor.
+    ///   Otherwise returns null.
+    /// </summary>
+    class TextLocalizer_Mock_Generic : ITextLocalizer
+    {
+        readonly ConcurrentDictionary<string, LanguageTag> m_appLanguages = new ConcurrentDictionary<string,LanguageTag>();
+        readonly ConcurrentDictionary<string, ConcurrentDictionary<string, string>> m_messages = new ConcurrentDictionary<string, ConcurrentDictionary<string, string>>();
+
+        public void AddAppLanguage(string langtag)
+        {
+            if (!m_appLanguages.ContainsKey(langtag))
+            {
+                m_appLanguages[langtag] = LanguageTag.GetCachedInstance(langtag);
+                m_messages[langtag] = new ConcurrentDictionary<string, string>();
+            }
+        }
+
+        public TextLocalizer_Mock_Generic()
+        {
+        }
+
+        public void AddMessage(string langtag, string msgid, string msgstr)
+        {
+            AddAppLanguage(langtag);
+            m_messages[langtag][msgid] = msgstr;
+        }
+
+    #region [ITextLocalizer]
+
+        public virtual ConcurrentDictionary<string, LanguageTag> GetAppLanguages()
+        {
+            return m_appLanguages;
+        }
+
+        public virtual string GetText(string msgid, string msgcomment, LanguageItem[] languages, out LanguageTag o_langtag, int maxPasses = -1)
+        {
+            string s1;
+            LanguageTag lt = LanguageMatching.MatchLists(
+                languages,
+                m_appLanguages.Values,
+                msgid,
+                null,
+                out s1,
+                maxPasses);
+           //
+            o_langtag = lt;
+            if (!lt.IsValid()) {
+                return null; }
+            if (!m_messages.ContainsKey(o_langtag.Language) || !m_messages[o_langtag.Language].ContainsKey(msgid))
+                return null;
+            return
+                m_messages[o_langtag.Language][msgid];
+        }
+
+    #endregion
+
+    }
+}

--- a/src/i18n.Tests/Tests/NuggetLocalizerTests.cs
+++ b/src/i18n.Tests/Tests/NuggetLocalizerTests.cs
@@ -155,6 +155,28 @@ namespace i18n.Tests
             Assert.AreEqual(obj.ProcessNuggets("[[[The %0 has not been saved. Would you like to save the changes?|||(((Current %0|||(((Order))))))]]]", pt), "O Pedido atual não foi salvo. Deseja salvar as mudanças?");
         }
 
+        [TestMethod]
+        [Description("Can translate recursive parameters.")]
+        public void NuggetLocalizer_can_translate_conditional()
+        {
+            var textLocalizer = new TextLocalizer_Mock_Generic();
+            textLocalizer.AddMessage("en", "%0_PRODUCTS_ADDED_TO_ORDER", "%0{0:No products were added|1:1 product was added|%0 products were added} to your order.");
+            textLocalizer.AddMessage("pt", "%0_PRODUCTS_ADDED_TO_ORDER", "%0{0:Nenhum produto foi adicionado|1:1 produto foi adicionado|%0 produtos foram adicionados} ao seu pedido.");
+
+            LanguageItem[] pt = LanguageItem.ParseHttpLanguageHeader("pt");
+            LanguageItem[] en = LanguageItem.ParseHttpLanguageHeader("en");
+
+            i18n.NuggetLocalizer obj = new i18n.NuggetLocalizer(new i18nSettings(new WebConfigSettingService(null)), textLocalizer);
+
+            Assert.AreEqual(obj.ProcessNuggets("[[[%0_PRODUCTS_ADDED_TO_ORDER|||0]]]", pt), "Nenhum produto foi adicionado ao seu pedido.");
+            Assert.AreEqual(obj.ProcessNuggets("[[[%0_PRODUCTS_ADDED_TO_ORDER|||1]]]", pt), "1 produto foi adicionado ao seu pedido.");
+            Assert.AreEqual(obj.ProcessNuggets("[[[%0_PRODUCTS_ADDED_TO_ORDER|||3]]]", pt), "3 produtos foram adicionados ao seu pedido.");
+
+            Assert.AreEqual(obj.ProcessNuggets("[[[%0_PRODUCTS_ADDED_TO_ORDER|||0]]]", en), "No products were added to your order.");
+            Assert.AreEqual(obj.ProcessNuggets("[[[%0_PRODUCTS_ADDED_TO_ORDER|||1]]]", en), "1 product was added to your order.");
+            Assert.AreEqual(obj.ProcessNuggets("[[[%0_PRODUCTS_ADDED_TO_ORDER|||3]]]", en), "3 products were added to your order.");
+        }
+
 
     }
 }

--- a/src/i18n.Tests/Tests/NuggetLocalizerTests.cs
+++ b/src/i18n.Tests/Tests/NuggetLocalizerTests.cs
@@ -99,7 +99,7 @@ namespace i18n.Tests
             i18n.NuggetLocalizer obj = new i18n.NuggetLocalizer(new i18nSettings(new WebConfigSettingService()), textLocalizer);
 
             string pre = "[[[Will occur %0 every %1 years|||April|||///First variable is a month]]]";
-                // Value for second variable is missing.
+            // Value for second variable is missing.
             string post = obj.ProcessNuggets(pre, languages);
             Assert.AreEqual("Will occur April every  years", post);
         }
@@ -113,7 +113,6 @@ namespace i18n.Tests
             i18n.NuggetLocalizer obj = new i18n.NuggetLocalizer(new i18nSettings(new WebConfigSettingService(null)), textLocalizer);
 
             string pre = "[[[%0 is required|||(((ZipCode)))]]]";
-            // Value for second variable is missing.
             string post = obj.ProcessNuggets(pre, languages);
             Assert.AreEqual("!!ZipCode! is required!", post);
         }
@@ -134,6 +133,28 @@ namespace i18n.Tests
             string post = obj.ProcessNuggets(pre, languages);
             Assert.AreEqual("!xxx123yyy! !xxx456yyy!", post);
         }
+
+        [TestMethod]
+        [Description("Can translate recursive parameters.")]
+        public void NuggetLocalizer_can_translate_recursive_parameter()
+        {
+            var textLocalizer = new TextLocalizer_Mock_Generic();
+            textLocalizer.AddMessage("pt", "Product", "Produto");
+            textLocalizer.AddMessage("pt", "Order", "Pedido");
+            textLocalizer.AddMessage("pt", "%0 Status", "Status do %0");
+            textLocalizer.AddMessage("pt", "Current %0", "%0 atual");
+            textLocalizer.AddMessage("pt", "Please select a %0", "Por favor escolha o %0");
+            textLocalizer.AddMessage("pt", "The %0 has not been saved. Would you like to save the changes?", "O %0 não foi salvo. Deseja salvar as mudanças?");
+
+            LanguageItem[] pt = LanguageItem.ParseHttpLanguageHeader("pt");
+
+            i18n.NuggetLocalizer obj = new i18n.NuggetLocalizer(new i18nSettings(new WebConfigSettingService(null)), textLocalizer);
+
+            Assert.AreEqual(obj.ProcessNuggets("[[[Please select a %0|||(((%0 Status|||(((Order))))))]]]", pt), "Por favor escolha o Status do Pedido");
+            Assert.AreEqual(obj.ProcessNuggets("[[[Please select a %0|||(((%0 Status|||(((Product))))))]]]", pt), "Por favor escolha o Status do Produto");
+            Assert.AreEqual(obj.ProcessNuggets("[[[The %0 has not been saved. Would you like to save the changes?|||(((Current %0|||(((Order))))))]]]", pt), "O Pedido atual não foi salvo. Deseja salvar as mudanças?");
+        }
+
 
     }
 }

--- a/src/i18n.Tests/Tests/NuggetLocalizerTests.cs
+++ b/src/i18n.Tests/Tests/NuggetLocalizerTests.cs
@@ -177,6 +177,30 @@ namespace i18n.Tests
             Assert.AreEqual(obj.ProcessNuggets("[[[%0_PRODUCTS_ADDED_TO_ORDER|||3]]]", en), "3 products were added to your order.");
         }
 
+        [TestMethod]
+        [Description("Can translate conditional extension_attributes.")]
+        public void NuggetLocalizer_can_translate_conditional_extension_attributes()
+        {
+            var textLocalizer = new TextLocalizer_Mock_Generic();
+            textLocalizer.AddMessage("pt", "Product", "Produto");
+            textLocalizer.AddMessage("pt", "Invoice", "Nota Fiscal");
+
+            // In Portuguese all nouns have gender - they are either masculine (m) or feminine (f)
+            textLocalizer.AddMessage("pt", "Product_GENDER", "M"); // product is masculine
+            textLocalizer.AddMessage("pt", "Invoice_GENDER", "F"); // invoice is feminine
+
+            // In Portuguese all adjectives/articles/quantifiers/etc are inflected in gender according to the noun.
+            // Translations can use those extension attributes to make decisions
+
+            textLocalizer.AddMessage("pt", "Your %0 was saved.", "(((%0_GENDER))){M:O %0 foi salvo.|F:A %0 foi salva.}");
+
+            LanguageItem[] pt = LanguageItem.ParseHttpLanguageHeader("pt");
+
+            i18n.NuggetLocalizer obj = new i18n.NuggetLocalizer(new i18nSettings(new WebConfigSettingService(null)), textLocalizer);
+
+            Assert.AreEqual(obj.ProcessNuggets("[[[Your %0 was saved.|||(((Product)))]]]", pt), "O Produto foi salvo.");
+            Assert.AreEqual(obj.ProcessNuggets("[[[Your %0 was saved.|||(((Invoice)))]]]", pt), "A Nota Fiscal foi salva.");
+        }
 
     }
 }

--- a/src/i18n.Tests/Tests/NuggetLocalizerTests.cs
+++ b/src/i18n.Tests/Tests/NuggetLocalizerTests.cs
@@ -156,7 +156,7 @@ namespace i18n.Tests
         }
 
         [TestMethod]
-        [Description("Can translate recursive parameters.")]
+        [Description("Can translate conditional parameters.")]
         public void NuggetLocalizer_can_translate_conditional()
         {
             var textLocalizer = new TextLocalizer_Mock_Generic();

--- a/src/i18n.Tests/i18n.Tests.csproj
+++ b/src/i18n.Tests/i18n.Tests.csproj
@@ -47,6 +47,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Helpers\TextLocalizer_Mock_Generic.cs" />
     <Compile Include="Helpers\TextLocalizer_Mock_SingleMessage.cs" />
     <Compile Include="Helpers\TextLocalizer_Mock_PrefixSuffix.cs" />
     <Compile Include="Tests\LanguageMatchingTests.cs" />

--- a/src/i18n/Concrete/NuggetLocalizer.cs
+++ b/src/i18n/Concrete/NuggetLocalizer.cs
@@ -29,7 +29,10 @@ namespace i18n
                 _settings.NuggetBeginToken,
                 _settings.NuggetEndToken,
                 _settings.NuggetDelimiterToken,
-                _settings.NuggetCommentToken),
+                _settings.NuggetCommentToken,
+                _settings.NuggetParameterBeginToken,
+                _settings.NuggetParameterEndToken
+                ),
                 NuggetParser.Context.ResponseProcessing);
         }
 
@@ -82,7 +85,11 @@ namespace i18n
                             if (formatItems[i] == null || !formatItems[i].Contains(_settings.NuggetParameterBeginToken)) continue;
 
                             // replace parameter tokens with nugget tokens 
-                            var fItem = formatItems[i].Replace(_settings.NuggetParameterBeginToken, _settings.NuggetBeginToken).Replace(_settings.NuggetParameterEndToken, _settings.NuggetEndToken);
+                            var fItem = formatItems[i];
+                            if (fItem.StartsWith(_settings.NuggetParameterBeginToken) && fItem.EndsWith(_settings.NuggetParameterEndToken))
+                                fItem = _settings.NuggetBeginToken
+                                + fItem.Substring(_settings.NuggetParameterBeginToken.Length, fItem.Length - _settings.NuggetParameterBeginToken.Length - _settings.NuggetParameterEndToken.Length)
+                                + _settings.NuggetEndToken;
                             // and process nugget 
                             formatItems[i] = ProcessNuggets(fItem, languages);
                         }


### PR DESCRIPTION
#### Extension Attributes

Conditionals allow you to create conditional translations depending on the argument itself, but sometimes the decision must not be made on something that you know in advance but rather on some language-specific attribute.
For example, "map" in portuguese is masculine gender but in french it's feminine gender.

Portuguese:
```
[[[The %0 is being exported.]]] -> "%0_GENDER{M:O %0 está sendo exportado.|A %0 está sendo exportada.}" 
[[[map]]] -> "mapa"
[[[map_GENDER]]] -> "M"
[[[The %0 is being exported.|||(((map)))]]]  -> "O mapa está sendo exportado" (masculine)
```

French:
```
[[[The %0 is being exported.]]] -> "%0_GENDER{M:Le %0 a été exporté.|F:La %0 a été exporté.}"
[[[map]]] -> "carte"
[[[map_GENDER]]] -> "F"
[[[The %0 is being exported.|||(((map)))]]]  -> "Le carte a été exporté" (feminine)
```

This is based on https://github.com/siefca/i18n-inflector