### PR TITLE
Display inner exception if available during post build 

### DIFF
--- a/src/i18n.PostBuild/Program.cs
+++ b/src/i18n.PostBuild/Program.cs
@@ -36,6 +36,15 @@ namespace i18n.PostBuild
             catch (Exception exception)
             {
                 Console.WriteLine("ERROR: {0}", exception.Message);
+                if (exception.InnerException == null)
+                {
+                    return;
+                }
+                while (exception.InnerException != null)
+                {
+                    exception = exception.InnerException;
+                }
+                Console.WriteLine("Error (InnerException): {0}", exception.Message);
             }
         }
 


### PR DESCRIPTION
If `Web.config` contains errors, such as an unrecognized attribute it's difficult to determine the actual error without the inner exception since it basically reads the following: 

`ERROR: Could not load configuration. Either incorrect path was sent in or if no path was sent in web.config could not be found where expected`

With this PR you can easily spot the error:

`"Unrecognized attribute 'name'. Note that attribute names are case-sensitive. (C:\\Users\\user\\Documents\\GitHub\\www.mysite.no\\src\\www.mysite.no\\Web.config line 63)"`

/cc @turquoiseowl 