### PR TITLE
Quick fix for allowing unicode encoded strings to be translated #355

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ publish.xml
 TestResults
 *.nupkg
 /src/packages
+src/.vs/

--- a/src/i18n.Tests/Tests/NuggetLocalizerTests.cs
+++ b/src/i18n.Tests/Tests/NuggetLocalizerTests.cs
@@ -135,5 +135,21 @@ namespace i18n.Tests
             Assert.AreEqual("!xxx123yyy! !xxx456yyy!", post);
         }
 
+        [TestMethod]
+        public void NuggetLocalizer_can_translate_unicode_nugget()
+        {
+            var textLocalizer = new TextLocalizer_Mock_SingleMessage("foo&bar", "blahblah");
+            var obj = new NuggetLocalizer(new i18nSettings(new WebConfigSettingService()), textLocalizer);
+
+            // Lookup HtmlEncoded msgid.
+            var pre = "[[[foo\u0026amp;bar]]]";
+            var post = obj.ProcessNuggets(pre, languages);
+            Assert.AreEqual("blahblah", post);
+
+            // Lookup un-HtmlEncoded msgid.
+            pre = "[[[foo\u0026bar]]]";
+            post = obj.ProcessNuggets(pre, languages);
+            Assert.AreEqual("blahblah", post);
+        }
     }
 }

--- a/src/i18n/Abstract/IEarlyUrlLocalizer.cs
+++ b/src/i18n/Abstract/IEarlyUrlLocalizer.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace i18n
+﻿namespace i18n
 {
     public interface IEarlyUrlLocalizer
     {

--- a/src/i18n/Abstract/IRootServices.cs
+++ b/src/i18n/Abstract/IRootServices.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using i18n.Domain.Abstract;
+﻿using i18n.Domain.Abstract;
 
 namespace i18n
 {

--- a/src/i18n/Abstract/ITranslateSvc.cs
+++ b/src/i18n/Abstract/ITranslateSvc.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace i18n
+﻿namespace i18n
 {
     /// <summary>
     /// Abstracts a translation service.

--- a/src/i18n/Concrete/NuggetLocalizer.cs
+++ b/src/i18n/Concrete/NuggetLocalizer.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text;
 using System.Text.RegularExpressions;
 using i18n.Helpers;
 using i18n.Domain.Concrete;

--- a/src/i18n/Concrete/TextLocalizer.cs
+++ b/src/i18n/Concrete/TextLocalizer.cs
@@ -5,6 +5,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using i18n.Domain.Abstract;
 using i18n.Domain.Entities;
 using i18n.Domain.Concrete;
@@ -172,6 +173,8 @@ namespace i18n
 
             // Lookup specific message text in the language PO and if found...return that.
             string text = LookupText(langtag, msgkey);
+            if (text == null) {
+                text = LookupText(langtag, UnescapeUnicodeCharacters(msgkey)); }
             if (text != null) {
                 return text; }
 
@@ -183,6 +186,17 @@ namespace i18n
 
             // Lookup failed.
             return null;
+        }
+
+
+        /// <summary>
+        /// Replaces escaped unicode characters with their corresponding unescaped character.
+        /// </summary>
+        /// <param name="msgkey">Key of the message to lookup, containing the escaped the characters.</param>
+        /// <returns>The unescpaed msgkey.</returns>
+        private static string UnescapeUnicodeCharacters(string msgkey)
+        {
+            return Regex.Replace(msgkey, @"\\u(?<Value>[a-zA-Z0-9]{4})", m => ((char) int.Parse(m.Groups["Value"].Value, NumberStyles.HexNumber)).ToString());
         }
 
         private bool LoadMessagesIntoCache(string langtag)

--- a/src/i18n/Concrete/TranslateSvc.cs
+++ b/src/i18n/Concrete/TranslateSvc.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using i18n;
 
 namespace i18n
 {

--- a/src/i18n/Concrete/UrlLocalizer.cs
+++ b/src/i18n/Concrete/UrlLocalizer.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Text.RegularExpressions;
 using i18n.Helpers;
 

--- a/src/i18n/Helpers/DebugHelpers.cs
+++ b/src/i18n/Helpers/DebugHelpers.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Diagnostics;
-using System.Text;
 using System.Threading;
 
 namespace i18n.Helpers

--- a/src/i18n/Helpers/HttpContextExtensions.cs
+++ b/src/i18n/Helpers/HttpContextExtensions.cs
@@ -1,8 +1,5 @@
 ﻿using System;
-using System.Threading;
-using System.Globalization;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 using i18n.Helpers;
 

--- a/src/i18n/Helpers/LanguageHelpers.cs
+++ b/src/i18n/Helpers/LanguageHelpers.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Collections.Concurrent;
-using System.Linq;
-using System.Text;
+﻿using System.Collections.Concurrent;
 
 namespace i18n
 {

--- a/src/i18n/Helpers/LanguageItem.cs
+++ b/src/i18n/Helpers/LanguageItem.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using i18n.Helpers;
 
 namespace i18n

--- a/src/i18n/Helpers/LanguageMatching.cs
+++ b/src/i18n/Helpers/LanguageMatching.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace i18n
 {

--- a/src/i18n/Helpers/ParseHelpers.cs
+++ b/src/i18n/Helpers/ParseHelpers.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Diagnostics;
-using System.Text;
 
 namespace i18n
 {

--- a/src/i18n/Helpers/TextLocalizerExtensions.cs
+++ b/src/i18n/Helpers/TextLocalizerExtensions.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace i18n.Helpers
+﻿namespace i18n.Helpers
 {
     public static class TextLocalizerExtensions
     {

--- a/src/i18n/LocalizedApplication.cs
+++ b/src/i18n/LocalizedApplication.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Threading;
 using System.Text.RegularExpressions;
-using i18n.Domain.Helpers;
 using i18n.Helpers;
 using i18n.Domain.Abstract;
 using i18n.Domain.Concrete;

--- a/src/i18n/Pipeline/LocalizingModule.cs
+++ b/src/i18n/Pipeline/LocalizingModule.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Text.RegularExpressions;
 using i18n.Helpers;
 
 namespace i18n

--- a/src/i18n/Pipeline/ResponseFilter.cs
+++ b/src/i18n/Pipeline/ResponseFilter.cs
@@ -1,9 +1,7 @@
 ﻿using System;
-using System.Linq;
 using System.IO;
 using System.Text;
 using i18n.Helpers;
-using i18n.Domain.Concrete;
 
 namespace i18n
 {

--- a/src/i18n/Properties/AssemblyInfo.cs
+++ b/src/i18n/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 [assembly: AssemblyVersion("2.1.11")]


### PR DESCRIPTION
The following modification allows also JSON encoded responses to be translated correctly.