### PR TITLE
Fixed bug described in issue #351

### DIFF
--- a/src/i18n.Domain/Concrete/POTranslationRepository.cs
+++ b/src/i18n.Domain/Concrete/POTranslationRepository.cs
@@ -444,13 +444,19 @@ namespace i18n.Domain.Concrete
                             var flags              = new HashSet<string>();
                             var references         = new List<ReferenceContext>();
 
+                            //based on PO files format the white space is delimiter between entries http://www.gnu.org/savannah-checkouts/gnu/gettext/manual/html_node/PO-Files.html
+                            if (string.IsNullOrWhiteSpace(line))
+                            {
+                                itemStarted = true;
+                                line = fs.ReadLine();
+                            }
+
                             //read all comments, flags and other descriptive items for this string
                             //if we have #~ its a historical/log entry but it is the messageID/message so we skip this do/while
-                            if (line.StartsWith("#") && !line.StartsWith("#~"))
+                            if (line != null && line.StartsWith("#") && !line.StartsWith("#~"))
                             {
                                 do
                                 {
-                                    itemStarted = true;
                                     switch (line[1])
                                     {
                                         case '.': //Extracted comments


### PR DESCRIPTION
#351 
Changed condition to mark position as a start of new entry. Before only # character was entries delimiter. 
@turquoiseowl do you have any PO files examples which I can test locally after these changes?
Also, what do you think about code refactoring for POTranslationRepository.ParseTranslationFile method? I see benefits from doing so as ability to unit test file parsing operations and create separate class for it like POFileParser or something like that. Current ParseTranslationFile method is big and can be reduced.