### PR TITLE
Rewrite http response headers only in ResponseFilter Flush method. 

### DIFF
--- a/src/i18n.Domain/Helpers/StringExtensions.cs
+++ b/src/i18n.Domain/Helpers/StringExtensions.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using i18n.Domain.Helpers;
-
-namespace i18n.Helpers
+﻿namespace i18n.Helpers
 {
     public static class StringExtensions
     {

--- a/src/i18n.Tests/Tests/ResponseFilterTests.cs
+++ b/src/i18n.Tests/Tests/ResponseFilterTests.cs
@@ -30,7 +30,7 @@ namespace i18n.Tests
             fakeContext.Response.Returns(fakeResponse);
 
             i18n.EarlyUrlLocalizer obj = new i18n.EarlyUrlLocalizer(new UrlLocalizer());
-            string post = obj.ProcessOutgoing(pre, suffix, fakeContext);
+            string post = obj.ProcessOutgoingNuggets(pre, suffix, fakeContext);
             Assert.AreEqual(expectedPatched, post);
         }
 

--- a/src/i18n/Abstract/IEarlyUrlLocalizer.cs
+++ b/src/i18n/Abstract/IEarlyUrlLocalizer.cs
@@ -1,4 +1,6 @@
-﻿namespace i18n
+﻿using System.Web;
+
+namespace i18n
 {
     public interface IEarlyUrlLocalizer
     {
@@ -28,9 +30,16 @@
         /// <returns>
         /// Processed (and possibly modified) entity.
         /// </returns>
-        string ProcessOutgoing(
+        string ProcessOutgoingNuggets(
             string entity, 
             string langtag, 
             System.Web.HttpContextBase context);
+
+        /// <summary>
+        /// Localize any HTTP headers in the response containing URLs.
+        /// </summary>
+        /// <param name="langtag">Langtag to be patched into URLs</param>
+        /// <param name="context">Http context which headers to rewrite</param>
+        void ProcessOutgoingHeaders(string langtag, HttpContextBase context);
     }
 }

--- a/src/i18n/Helpers/HttpContextExtensions.cs
+++ b/src/i18n/Helpers/HttpContextExtensions.cs
@@ -110,7 +110,7 @@ namespace i18n
             if (UrlLocalizer.UrlLocalizationScheme != UrlLocalizationScheme.Void) {
                 var earlyUrlLocalizer = LocalizedApplication.Current.EarlyUrlLocalizerForApp;
                 if (earlyUrlLocalizer != null) {
-                    entity = earlyUrlLocalizer.ProcessOutgoing(
+                    entity = earlyUrlLocalizer.ProcessOutgoingNuggets(
                         entity, 
                         context.GetPrincipalAppLanguageForRequest().ToString(),
                         context); }

--- a/src/i18n/Pipeline/ResponseFilter.cs
+++ b/src/i18n/Pipeline/ResponseFilter.cs
@@ -152,10 +152,13 @@ namespace i18n
             //   <link href="..."> tags
             if (m_earlyUrlLocalizer != null)
             {
-                entity = m_earlyUrlLocalizer.ProcessOutgoing(
-                    entity, 
-                    m_httpContext.GetPrincipalAppLanguageForRequest().ToString(),
+                var langtag = m_httpContext.GetPrincipalAppLanguageForRequest().ToString();
+
+                entity = m_earlyUrlLocalizer.ProcessOutgoingNuggets(
+                    entity, langtag,
                     m_httpContext);
+
+                 m_earlyUrlLocalizer.ProcessOutgoingHeaders(langtag, m_httpContext);
             }
 
             //DebugHelpers.WriteLine("ResponseFilter::Write -- entity:\n{0}", entity);


### PR DESCRIPTION
Made changes as suggested in #338
Extract http headers rewrite as separate method ProcessOutgoingHeaders.
Call ProcessOutgoingHeaders only when flushing http response.
ProcessOutgoingHeaders - make positive logic cases only.
StringExtensions.cs - removed unused references.

